### PR TITLE
Allow forward slash in DOI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/__pycache__
 .cache
-
+venv/
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -57,7 +57,7 @@ mapping:
     # + at least one character of small or capital letters, digits, 
     # any of the following whitespace-separated characters: 
     # - . _ ; ( ) [ ] \ : 
-    pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:]+$
+    pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:/]+$
 
   keywords:
     required: False
@@ -295,7 +295,7 @@ schema;reference:
       # + at least one character of small or capital letters, digits, 
       # any of the following whitespace-separated characters: 
       # - . _ ; ( ) [ ] \ : 
-      pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:]+$
+      pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:/]+$
 
     collection-title: 
       required: False
@@ -374,7 +374,7 @@ schema;reference:
       # + at least one character of small or capital letters, digits, 
       # any of the following whitespace-separated characters: 
       # - . _ ; ( ) [ ] \ : 
-      pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:]+$
+      pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:/]+$
 
     edition:  
       required: False

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,4 +1,4 @@
-name: "Citation File Format - Core module (CFF-Core) schema 1.0.3"
+name: "Citation File Format - Core module (CFF-Core) schema 1.1.0"
 desc: A pykwalifire schema for validating CITATION.cff files 
 type: map
 mapping:
@@ -7,7 +7,7 @@ mapping:
   cff-version:
     required: True
     type: str
-    pattern: 1\.0\.3
+    pattern: 1\.1\.0
 
   # Message
   message:

--- a/schema.yaml
+++ b/schema.yaml
@@ -56,7 +56,7 @@ mapping:
     # + '/'
     # + at least one character of small or capital letters, digits, 
     # any of the following whitespace-separated characters: 
-    # - . _ ; ( ) [ ] \ : 
+    # - . _ ; ( ) [ ] \ : /
     pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:/]+$
 
   keywords:
@@ -294,7 +294,7 @@ schema;reference:
       # + '/'
       # + at least one character of small or capital letters, digits, 
       # any of the following whitespace-separated characters: 
-      # - . _ ; ( ) [ ] \ : 
+      # - . _ ; ( ) [ ] \ : /
       pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:/]+$
 
     collection-title: 
@@ -373,7 +373,7 @@ schema;reference:
       # + '/'
       # + at least one character of small or capital letters, digits, 
       # any of the following whitespace-separated characters: 
-      # - . _ ; ( ) [ ] \ : 
+      # - . _ ; ( ) [ ] \ : /
       pattern: ^10\.\d{4,9}(\.\d+)?/[A-Za-z0-9-\._;\(\)\[\]\\\\:/]+$
 
     edition:  

--- a/test/1.1.0/doi-with-slash/CITATION.cff
+++ b/test/1.1.0/doi-with-slash/CITATION.cff
@@ -1,0 +1,32 @@
+# YAML 1.2
+# Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
+cff-version: 1.0.3
+message: If you use this software, please cite it using these metadata.
+title: 'ANNIS'
+doi: 10.5281/zenodo.2563138
+authors:
+- given-names: Dummy
+  family-names: User
+  affiliation: Humboldt-Universität zu Berlin
+  orcid: https://orcid.org/0000-1234-5678-9101
+version: annis-3.6.0
+date-released: 2019-02-12
+repository-code: https://github.com/korpling/ANNIS
+license:  Apache-2.0
+references:
+  - type: article
+    title: "ANNIS3: A new architecture for generic corpus query and visualization"
+    year: 2016
+    doi: 10.1093/llc/fqu057
+    authors:
+      - family-names: Dummy
+        given-names: User
+        orcid: https://orcid.org/0000-1234-5678-9101
+        affiliation: Humboldt-Universität zu Berlin
+      - family-names: Other
+        given-names: User
+        affiliation: Georgetown University
+    journal: Digital Scholarship in the Humanities
+    volume: 31
+    issue: "1"
+    issn: 2055-7671

--- a/test/1.1.0/doi-with-slash/CITATION.cff
+++ b/test/1.1.0/doi-with-slash/CITATION.cff
@@ -1,6 +1,6 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
-cff-version: 1.0.3
+cff-version: 1.1.0
 message: If you use this software, please cite it using these metadata.
 title: 'ANNIS'
 doi: 10.5281/zenodo.2563138

--- a/test/1.1.0/doi-with-slash/test_doi_with_slash.py
+++ b/test/1.1.0/doi-with-slash/test_doi_with_slash.py
@@ -1,0 +1,22 @@
+import pytest
+import os
+from cffconvert import Citation
+
+def get_sibling_cff():
+    realpath = os.path.realpath(__file__)
+    dir = os.path.dirname(realpath)
+    return os.path.join(dir, "CITATION.cff")
+
+
+@pytest.fixture(scope="module")
+def cffstr():
+    fixture = get_sibling_cff()
+    with open(fixture, "r") as f:
+        s = f.read()
+    return s
+
+
+def test1(cffstr):
+    citation = Citation(cffstr=cffstr, suspect_keys=[], validate=True, raise_exception=True)
+    assert citation.yaml is not None
+


### PR DESCRIPTION
This PR fixes #92.

Cherry-picked https://github.com/citation-file-format/schema/commit/c40ccac00896aa8532b76b46e6e5df709965bd13 by @sbliven to keep commit history and commit ownership.