### PR TITLE
added 'alias'

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ collections with a defined set of keys, of which only `family-names` and
 | -               | -                    | :------------: |
 | `family-names`  | String               |                |
 | `given-names`   | String               |                |
+| `alias`         | String               | ●              |
 | `name-particle` | String               | ●              |
 | `name-suffix`   | String               | ●              |
 | `affiliation`   | String               | ●              |
@@ -589,6 +590,10 @@ do not have the concept of family names, or Chinese generation names, but the
 alternative is highly localized customization, which would be counterintuitive
 as to CFF's goal to be easily accessible. Thus, it is ultimately the task of CFF
 file authors to find the optimal name split in any given case.
+
+**`alias`**
+
+- To specify a person who is only known by an alias such as a username.
 
 **`affiliation`**
 

--- a/README.md
+++ b/README.md
@@ -537,27 +537,26 @@ orcid: https://orcid.org/0000-0001-2345-6789
 ## Person objects
 
 A person object represents a person. In CFF, person objects are realized as
-collections with a defined set of keys, of which only `family-names` and
-`given-names` are mandatory.
+collections with a defined set of keys.
 
-| Person key      | Person data type     | optional       |
-| -               | -                    | :------------: |
-| `family-names`  | String               |                |
-| `given-names`   | String               |                |
-| `alias`         | String               | ●              |
-| `name-particle` | String               | ●              |
-| `name-suffix`   | String               | ●              |
-| `affiliation`   | String               | ●              |
-| `address`       | String               | ●              |
-| `city`          | String               | ●              |
-| `region`        | String               | ●              |
-| `post-code`     | String               | ●              |
-| `country`       | String               | ●              |
-| `orcid`         | String (*ORCID URL*) | ●              |
-| `email`         | String               | ●              |
-| `tel`           | String               | ●              |
-| `fax`           | String               | ●              |
-| `website`       | String (*URL*)       | ●              |
+| Person key      | Person data type     |
+| -               | -                    |
+| `family-names`  | String               |
+| `given-names`   | String               |
+| `alias`         | String               |
+| `name-particle` | String               |
+| `name-suffix`   | String               |
+| `affiliation`   | String               |
+| `address`       | String               |
+| `city`          | String               |
+| `region`        | String               |
+| `post-code`     | String               |
+| `country`       | String               |
+| `orcid`         | String (*ORCID URL*) |
+| `email`         | String               |
+| `tel`           | String               |
+| `fax`           | String               |
+| `website`       | String (*URL*)       |
 
 
 ### Exemplary uses

--- a/schema.yaml
+++ b/schema.yaml
@@ -135,6 +135,10 @@ schema;person:
       required: True
       type: str
     
+    alias:
+      required: False
+      type: str
+
     name-particle:
       required: False
       type: str

--- a/schema.yaml
+++ b/schema.yaml
@@ -128,11 +128,11 @@ schema;person:
   mapping:
 
     family-names: 
-      required: True
+      required: False
       type: str
     
     given-names: 
-      required: True
+      required: False
       type: str
     
     alias:

--- a/test/1.1.0/alias-minimal/CITATION.cff
+++ b/test/1.1.0/alias-minimal/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.1.0
+message: If you use this software, please cite it as below.
+authors:
+  - alias: githubuser
+title: My Research Tool
+version: 1.0.4
+date-released: 2017-12-18

--- a/test/1.1.0/alias-minimal/test_alias_minimal.py
+++ b/test/1.1.0/alias-minimal/test_alias_minimal.py
@@ -1,0 +1,22 @@
+import pytest
+import os
+from cffconvert import Citation
+
+def get_sibling_cff():
+    realpath = os.path.realpath(__file__)
+    dir = os.path.dirname(realpath)
+    return os.path.join(dir, "CITATION.cff")
+
+
+@pytest.fixture(scope="module")
+def cffstr():
+    fixture = get_sibling_cff()
+    with open(fixture, "r") as f:
+        s = f.read()
+    return s
+
+
+def test1(cffstr):
+    citation = Citation(cffstr=cffstr, suspect_keys=[], validate=True, raise_exception=True)
+    assert citation.yaml is not None
+


### PR DESCRIPTION
- added optional key 'alias' to author schema
- updated the docs accordingly
- fixes #93

Furthermore,

- made ``family-names`` not required
- made ``given-names`` not required
- updated the readme accordingly.

This last change basically gives CFF writers more freedom and a bit more responsibility to strive for good data, but the benefit is that people can now write valid files when:
- an author is known only by an alias
- an author is known only by their family name
 