### PR TITLE
Adds URL based optional keys in root document

### DIFF
--- a/schema-sandbox/data.yml
+++ b/schema-sandbox/data.yml
@@ -5,3 +5,8 @@ authors:
   - name: "entity name"
   - given-names: "Given Names"
 commit: af34567890123458901234567890123456789012
+license-url: http://r3s34archs0ft.com/eula
+repository: https://github.com/citation-file-format/citation-file-format
+repository-code: https://github.com/citation-file-format/citation-file-format
+repository-artifact: https://files.pythonhosted.org/packages/0a/84/10507b69a07768bc16981184b4d147a0fc84b71fbf35c03bafc8dcced8e1/cffconvert-1.3.3.tar.gz
+url: https://github.com/citation-file-format/citation-file-format

--- a/schema-sandbox/schema.json
+++ b/schema-sandbox/schema.json
@@ -39,6 +39,21 @@
             "type": "string",
             "description": "The commit SHA1 hash or revision number of the software version",
             "pattern": "^[a-f0-9]{7,40}$"
+        },
+        "license-url": {
+            "$ref": "#/definitions/url"
+        },
+        "repository": {
+            "$ref": "#/definitions/url"
+        },
+        "repository-code": {
+            "$ref": "#/definitions/url"
+        },
+        "repository-artifact": {
+            "$ref": "#/definitions/url"
+        },
+        "url": {
+            "$ref": "#/definitions/url"
         }
     },
     "required": [
@@ -64,6 +79,11 @@
                     "type": "string"
                 }
             }
+        },
+        "url": {
+            "type": "string",
+            "format": "uri",
+            "pattern": "^(?:(?:https?|ftp)://)(?:\\S+(?::\\S*)?@)?(?:(?!(?:10|127)(?:\\.\\d{1,3}){3})(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))|(?:(?:[a-z\\u00a1-\\uffff0-9]-?)*[a-z\\u00a1-\\uffff0-9]+)(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-?)*[a-z\\u00a1-\\uffff0-9]+)*(?:\\.(?:[a-z\\u00a1-\\uffff]{2,})))(?::\\d{2,5})?(?:/\\S*)?$"
         }
     }
 }


### PR DESCRIPTION
This PR adds url based optional keys `license-url`, `repository`, `repository-code`, `repository-artefact`,  `url`

Note the merge target is not `main` but `1.2.0`.

**How to test**

```shell
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
cd schema-sandbox
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```

