### PR TITLE
Adds validation of identifiers when type is url or doi

### DIFF
--- a/schema-sandbox/schema.json
+++ b/schema-sandbox/schema.json
@@ -89,27 +89,67 @@
             "type": "string"
         },
         "identifier": {
-            "additionalProperties": false,
-            "properties": {
-                "type": {
-                    "enum": [
-                        "doi",
-                        "other",
-                        "swh",
-                        "url"
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "doi"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/doi"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value"
                     ],
-                    "type": "string"
+                    "type": "object"
                 },
-                "value": {
-                    "minLength": 1,
-                    "type": "string"
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "url"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/url"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "other",
+                                "swh"
+                            ],
+                            "type": "string"
+                        },
+                        "value": {
+                            "minLength": 1,
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value"
+                    ],
+                    "type": "object"
                 }
-            },
-            "required": [
-                "type",
-                "value"
-            ],
-            "type": "object"
+            ]
         },
         "person": {
             "type": "object",


### PR DESCRIPTION
Merge target is `1.2.0`
Refs #126 
Includes: PR #124

Can be marked _ready for review_ after merge of PR #124

This PR adds validation of `identifiers` array members, using validation regular expressions from `#/definitions/url` and `#/definitions/doi`.

`identifiers` of `type` `other` and `swh` remain unvalidated for the moment.