### PR TITLE
language code validation

### DIFF
--- a/schema-sandbox/schema.json
+++ b/schema-sandbox/schema.json
@@ -326,7 +326,7 @@
                 "languages": {
                     "type": "array",
                     "items": {
-                        "format": "^[a-z]{2,3}$",
+                        "pattern": "^[a-z]{2,3}$",
                         "maxLength": 3,
                         "minLength": 2,
                         "type": "string"

--- a/schema-sandbox/schema.json
+++ b/schema-sandbox/schema.json
@@ -286,8 +286,10 @@
                 "languages": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "format": "^[a-z]{2,3}$"
+                        "format": "^[a-z]{2,3}$",
+                        "maxLength": 3,
+                        "minLength": 2,
+                        "type": "string"
                     },
                     "uniqueItems": true,
                     "minItems": 1

--- a/schema-sandbox/schema.json
+++ b/schema-sandbox/schema.json
@@ -287,7 +287,7 @@
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "maxLength": 3
+                        "format": "^[a-z]{2,3}$"
                     },
                     "uniqueItems": true,
                     "minItems": 1


### PR DESCRIPTION
Refs #127
Merge target `1.2.0`
Inlcludes PR #124

This PR adds a bit more validation for language codes in the key `languages`. I tested the regular expression on regex101.com using all the keys we had previously, they are all recognized
