### PR TITLE
Remove commit regex

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -38,8 +38,7 @@
             }
         },
         "commit": {
-            "type": "string",
-            "description": "The commit SHA1 hash or revision number of the software version",
+            "$ref": "#/definitions/commit"
         },
         "contact": {
             "type": "array",
@@ -121,6 +120,10 @@
         "version"
     ],
     "definitions": {
+        "commit": {
+            "type": "string",
+            "description": "The commit SHA1 hash or revision number of the software version"
+        },
         "country": {
             "type": "string",
             "enum": [
@@ -1011,8 +1014,7 @@
                     "type": "string"
                 },
                 "commit": {
-                    "type": "string",
-                    "pattern": "^[a-f0-9]{7,40}$"
+                    "$ref": "#/definitions/commit"
                 },
                 "conference": {
                     "$ref": "#/definitions/entity"

--- a/schema.json
+++ b/schema.json
@@ -40,7 +40,6 @@
         "commit": {
             "type": "string",
             "description": "The commit SHA1 hash or revision number of the software version",
-            "pattern": "^[a-f0-9]{7,40}$"
         },
         "contact": {
             "type": "array",


### PR DESCRIPTION
**Related issues**

Refs: n/a

**Describe the changes made in this pull request**

- Introduce a `commit` definition without a regex (`commit` is meant to take any revision or commit identifiers from any VCS, not just git SHA1 hashes).
- Reuse definition in two fields in schema

**Instructions to review the pull request**

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```
