### PR TITLE
Implement multi-licensed items

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -46,6 +46,7 @@ references:
       - 
         given-names: John
     title: this is the title
+    license: "GPL-2.0"
 repository: https://github.com/citation-file-format/citation-file-format
 repository-artifact: https://files.pythonhosted.org/packages/0a/84/10507b69a07768bc16981184b4d147a0fc84b71fbf35c03bafc8dcced8e1/cffconvert-1.3.3.tar.gz
 repository-code: https://github.com/citation-file-format/citation-file-format
@@ -53,3 +54,6 @@ title: my title
 type: software
 url: https://github.com/citation-file-format/citation-file-format
 version: "1.2.3"
+license: 
+  - "Apache-2.0"
+  - "MIT"

--- a/schema.json
+++ b/schema.json
@@ -509,6 +509,21 @@
             }
         },
         "license": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/_license-enum"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/_license-enum"
+                    },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "_license-enum": {
             "$comment": "SPDX license list; releaseDate=2021-05-14; source=https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json",
             "enum": [
                 "0BSD",

--- a/schema.json
+++ b/schema.json
@@ -511,19 +511,19 @@
         "license": {
             "oneOf": [
                 {
-                    "$ref": "#/definitions/_license-enum"
+                    "$ref": "#/definitions/license-enum"
                 },
                 {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/_license-enum"
+                        "$ref": "#/definitions/license-enum"
                     },
                     "minItems": 1,
                     "uniqueItems": true
                 }
             ]
         },
-        "_license-enum": {
+        "license-enum": {
             "$comment": "SPDX license list; releaseDate=2021-05-14; source=https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json",
             "enum": [
                 "0BSD",


### PR DESCRIPTION
This PR is against `1.2.0`!

**Related issues**

Refs: 
- fix #128 
- Doesn't supply a fix for #105

**Describe the changes made in this pull request**

- Move license enums to "private" definition `#/definitions/_license-enum`
- Re-define `#/definitions/license` to be `oneOf` `_license_enum` or an array pf `_license-enum`.
- Add test data to test both cases

**Instructions to review the pull request**

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```