### PR TITLE
Add GitHub actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Citation File Format (CFF)
-
+[![Build Status](https://github.com/citation-file-format/citation-file-format/workflows/testing/badge.svg)](https://github.com/citation-file-format/citation-file-format/actions/workflows/testing.yml)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4751536.svg)](https://doi.org/10.5281/zenodo.4751536)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 


### PR DESCRIPTION
This PR follows the comment by @jspaaks in #117 and adds CI badge.

You can see the rendered version of README in my fork here: https://github.com/alex-konovalov/citation-file-format/tree/add-gh-badge

I submitted it to 1.2.0 branch, but the URLs for the badge are resolved without specifying branch - so there will be no need to update them after 1.2.0 will be merged into main (I hope I got the workflow right - if I need to submit this to main instead, please let me know and I will rebase!).

