### PR TITLE
Fix #176: Add 'term' to reference

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1381,6 +1381,7 @@
                 },
                 "term": {
                     "description": "The term being referenced if the work is a dictionary or encyclopedia.",
+                    "minLength": 1,
                     "type": "string"
                 },
                 "title": {

--- a/schema.json
+++ b/schema.json
@@ -1379,6 +1379,10 @@
                 "start": {
                     "type": "integer"
                 },
+                "term": {
+                    "description": "The term being referenced if the work is a dictionary or encyclopedia.",
+                    "type": "string"
+                },
                 "title": {
                     "type": "string"
                 },


### PR DESCRIPTION
**Related issues**

Fixes #176

**Describe the changes made in this pull request**

- Add the `term` field (string) to the reference object
- Add a description for term

**Instructions to review the pull request**

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```

