### PR TITLE
Add default values for type and message

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -14,14 +14,16 @@
         "message": {
             "type": "string",
             "description": "A message to the (human) reader of the file to let them know what to do with the citation metadata",
-            "minLength": 1
+            "minLength": 1,
+            "default": "If you use this software, please cite it using the metadata from this file."
         },
         "type": {
             "type": "string",
             "enum": [
                 "dataset",
                 "software"
-            ]
+            ],
+            "default": "software"
         },
         "abstract": {
             "type": "string"


### PR DESCRIPTION
- Fix #185

**Describe the changes made in this pull request**

- Add default values for `message` and `type` as per #185.

**Instructions to review the pull request**

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```
