### PR TITLE
Add stricter validation for SWH identifiers

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -440,10 +440,28 @@
                     "properties": {
                         "type": {
                             "enum": [
-                                "other",
                                 "swh"
                             ],
-                            "type": "#/definitions/swh-identifier"
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/swh-identifier"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "value"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "other"
+                            ],
+                            "type": "string"
                         },
                         "value": {
                             "minLength": 1,
@@ -1484,7 +1502,7 @@
             "pattern": "^(https|http|ftp|sftp)://.+"
         },
         "swh-identifier": {
-            "$comment": "Software Heritage identifiers are documented here: https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html",
+            "$comment": "Software Heritage identifiers are documented here: https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html.",
             "description": "The Software Heritage identifier (without further qualifiers such as origin, visit, anchor, path).",
             "examples": [
                 "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2",

--- a/schema.json
+++ b/schema.json
@@ -443,7 +443,7 @@
                                 "other",
                                 "swh"
                             ],
-                            "type": "string"
+                            "type": "#/definitions/swh-identifier"
                         },
                         "value": {
                             "minLength": 1,
@@ -1482,6 +1482,19 @@
             "type": "string",
             "format": "uri",
             "pattern": "^(https|http|ftp|sftp)://.+"
+        },
+        "swh-identifier": {
+            "$comment": "Software Heritage identifiers are documented here: https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html",
+            "description": "The Software Heritage identifier (without further qualifiers such as origin, visit, anchor, path).",
+            "examples": [
+                "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2",
+                "swh:1:dir:d198bc9d7a6bcf6db04f476d29314f157507d505",
+                "swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d",
+                "swh:1:rel:22ece559cc7cc2364edc5e5593d63ae8bd229f9f",
+                "swh:1:snp:c7c108084bc0bf3d81436bf980b46e98bd338453"
+            ],
+            "type": "string",
+            "pattern": "^swh:1:(snp|rel|rev|dir|cnt):[0-9a-fA-F]{40}$"
         }
     }
 }


### PR DESCRIPTION
**Related issues**

Fix #179

**Describe the changes made in this pull request**

- Add a definition for unqualified SWH identifiers
- Separate the `swh` and `other` enums in the `identifier` definition
- Let `swh` use the new definition
- Note that the field takes unqualified identifiers only.

**Instructions to review the pull request**

- Check if we want to support qualified identifiers as well (cf. https://docs.softwareheritage.org/devel/swh-model/persistent-identifiers.html#qualifiers)

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```