### PR TITLE
Disallow empty strings as values

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -24,7 +24,8 @@
             ]
         },
         "abstract": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "authors": {
             "type": "array",
@@ -75,7 +76,8 @@
         },
         "keywords": {
             "items": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
             },
             "minItems": 1,
             "type": "array",
@@ -130,7 +132,8 @@
     "definitions": {
         "commit": {
             "type": "string",
-            "description": "The commit SHA1 hash or revision number of the software version"
+            "description": "The commit SHA1 hash or revision number of the software version",
+            "minLength": 1
         },
         "country": {
             "type": "string",
@@ -471,7 +474,8 @@
                     "$ref": "#/definitions/address"
                 },
                 "affiliation": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "alias": {
                     "$ref": "#/definitions/alias"
@@ -486,19 +490,23 @@
                     "$ref": "#/definitions/email"
                 },
                 "family-names": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "fax": {
                     "$ref": "#/definitions/fax"
                 },
                 "given-names": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "name-particle": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "name-suffix": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "orcid": {
                     "$ref": "#/definitions/orcid"
@@ -522,7 +530,8 @@
             "type": "string"
         },
         "tel": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "license": {
             "oneOf": [
@@ -1051,7 +1060,8 @@
                     "$ref": "#/definitions/date"
                 },
                 "location": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 }
             },
             "required": [
@@ -1059,22 +1069,28 @@
             ]
         },
         "address": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "alias": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "city": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "fax": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "post-code": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "region": {
-            "type": "string"
+            "type": "string",
+            "minLength": 1
         },
         "reference": {
             "additionalProperties": false,
@@ -1241,7 +1257,8 @@
                     "minLength": 1
                 },
                 "issue-date": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "issue-title": {
                     "type": "string",

--- a/schema.json
+++ b/schema.json
@@ -1080,10 +1080,12 @@
             "additionalProperties": false,
             "properties": {
                 "abbreviation": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "abstract": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "authors": {
                     "items": {
@@ -1104,10 +1106,12 @@
                     "$ref": "#/definitions/doi"
                 },
                 "collection-title": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "collection-type": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "commit": {
                     "$ref": "#/definitions/commit"
@@ -1131,13 +1135,16 @@
                     "uniqueItems": true
                 },
                 "copyright": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "data-type": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "database": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "database-provider": {
                     "$ref": "#/definitions/entity"
@@ -1155,7 +1162,8 @@
                     "$ref": "#/definitions/date"
                 },
                 "department": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "doi": {
                     "$ref": "#/definitions/doi"
@@ -1169,7 +1177,8 @@
                     "uniqueItems": true
                 },
                 "edition": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "editors": {
                     "items": {
@@ -1205,13 +1214,16 @@
                     "type": "integer"
                 },
                 "entry": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "filename": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "format": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "institution": {
                     "$ref": "#/definitions/entity"
@@ -1225,21 +1237,25 @@
                     "type": "string"
                 },
                 "issue": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "issue-date": {
                     "type": "string"
                 },
                 "issue-title": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "journal": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "keywords": {
                     "type": "array",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     },
                     "uniqueItems": true,
                     "minItems": 1
@@ -1271,7 +1287,8 @@
                     "type": "integer"
                 },
                 "medium": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "month": {
                     "enum": [
@@ -1291,23 +1308,29 @@
                     "type": "integer"
                 },
                 "nihmsid": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "notes": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "number": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "number-volumes": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "pages": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "patent-states": {
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "minLength": 1
                     },
                     "minItems": 1,
                     "type": "array",
@@ -1345,10 +1368,12 @@
                     "$ref": "#/definitions/url"
                 },
                 "scope": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "section": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "senders": {
                     "items": {
@@ -1380,10 +1405,12 @@
                     "type": "integer"
                 },
                 "title": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "thesis-type": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "translators": {
                     "items": {
@@ -1456,13 +1483,16 @@
                     "$ref": "#/definitions/url"
                 },
                 "version": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "volume": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "volume-title": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                 },
                 "year": {
                     "type": "integer"


### PR DESCRIPTION
**Related issues**

Refs: None

**Describe the changes made in this pull request**

- Requires a `minLength` of 1 for all string values, which blocks uninformative empty string fields (`""`).

