### PR TITLE
Fix #202 without breaking API

### DIFF
--- a/tests/1.2.0/poc/CITATION.cff
+++ b/tests/1.2.0/poc/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     region: My region
     tel: "1-34245-7346356-8467"
     website: https://my.domain/website/
-    date-start: 2021-05-16
+    date-start: 2021-05-1X
     date-end: 2021-05-16
     location: "somehwere"
   -
@@ -59,7 +59,15 @@ references:
         given-names: John
     title: this is the title
     license: "GPL-2.0"
-    issue-date: "2021-02-02"
+    issue-date: "2021-02-04"
+  - 
+    type: article
+    authors: 
+      - 
+        given-names: Johanna
+    title: "This is another title"
+    license: "Apache-2.0"
+    issue-date: "November-December 2002"
 repository: https://github.com/citation-file-format/citation-file-format
 repository-artifact: https://files.pythonhosted.org/packages/0a/84/10507b69a07768bc16981184b4d147a0fc84b71fbf35c03bafc8dcced8e1/cffconvert-1.3.3.tar.gz
 repository-code: https://github.com/citation-file-format/citation-file-format

--- a/tests/1.2.0/poc/CITATION.cff
+++ b/tests/1.2.0/poc/CITATION.cff
@@ -12,8 +12,8 @@ authors:
     region: My region
     tel: "1-34245-7346356-8467"
     website: https://my.domain/website/
-    date-start: "2021-05-16"
-    date-end: "2021-05-16"
+    date-start: 2021-05-16
+    date-end: 2021-05-16
     location: "somehwere"
   -
     address: My address 44
@@ -34,7 +34,7 @@ authors:
     website: https://my.domain/website/
 cff-version: 1.2.0
 commit: af34567890123458901234567890123456789012
-date-released: "2021-05-16"
+date-released: 2021-05-16
 identifiers:
 - type: doi
   value: "10.0000.1234/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._[]()\\:;"
@@ -59,6 +59,7 @@ references:
         given-names: John
     title: this is the title
     license: "GPL-2.0"
+    issue-date: "2021-02-02"
 repository: https://github.com/citation-file-format/citation-file-format
 repository-artifact: https://files.pythonhosted.org/packages/0a/84/10507b69a07768bc16981184b4d147a0fc84b71fbf35c03bafc8dcced8e1/cffconvert-1.3.3.tar.gz
 repository-code: https://github.com/citation-file-format/citation-file-format

--- a/tests/1.2.0/poc/CITATION.cff
+++ b/tests/1.2.0/poc/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     region: My region
     tel: "1-34245-7346356-8467"
     website: https://my.domain/website/
-    date-start: 2021-05-1X
+    date-start: 2021-05-16
     date-end: 2021-05-16
     location: "somehwere"
   -

--- a/tests/schema_poc.py
+++ b/tests/schema_poc.py
@@ -8,6 +8,7 @@ def validate(data_path, schema_path):
     with open(data_path, 'r') as fi:
         # Convert to Python object
         yaml = YAML(typ='safe')
+        yaml.constructor.yaml_constructors[u'tag:yaml.org,2002:timestamp'] = yaml.constructor.yaml_constructors[u'tag:yaml.org,2002:str']
         yml_data = yaml.load(fi)
 
         with open(schema_path, 'r') as sf:

--- a/tests/schema_poc.py
+++ b/tests/schema_poc.py
@@ -13,7 +13,7 @@ def validate(data_path, schema_path):
 
         with open(schema_path, 'r') as sf:
             schema_data = json.loads(sf.read())
-            jsonschema.validate(instance=yml_data, schema=schema_data)
+            jsonschema.validate(instance=yml_data, schema=schema_data, format_checker=jsonschema.FormatChecker())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements option 3. in https://github.com/citation-file-format/citation-file-format/issues/202#issuecomment-855801103 for our use case, validating test instances of `CITATION.cff` during CI.

This change doesn't break API, and is one way to solve this for Python clients using the `jsonschema` package.

**Related issues**

Refs: #202

**Describe the changes made in this pull request**

- Keep using YAML timestamp data for dates in CFF
- Change the way that YAML is being deserialized for validation in tests
(deserialize all timestamps as strings)
- Activate format checks in Python script (cf. [example for fail](https://github.com/citation-file-format/citation-file-format/runs/2731942670#step:7:26))
- Add some test data
- Note that this also allows for correctly formatted strings as values for dates!

**Instructions to review the pull request**

- Decide how to deal with #202, i.e. change date data type to string for CFF or not.
- Only then this PR can be merged, and to review do:

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 schema_poc.py -d data.yml -s schema.json  # <- should be quiet
```