### PR TITLE
Make version, date-released root fields optional

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -153,11 +153,9 @@
     },
     "required": [
         "authors",
-        "date-released",
         "cff-version",
         "message",
-        "title",
-        "version"
+        "title"
     ],
     "definitions": {
         "commit": {

--- a/tests/1.2.0/poc/CITATION.cff
+++ b/tests/1.2.0/poc/CITATION.cff
@@ -34,7 +34,6 @@ authors:
     website: https://my.domain/website/
 cff-version: 1.2.0
 commit: af34567890123458901234567890123456789012
-date-released: "2021-05-16"
 identifiers:
 - type: doi
   value: "10.0000.1234/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._[]()\\:;"
@@ -66,7 +65,6 @@ repository-code: https://github.com/citation-file-format/citation-file-format
 title: my title
 type: software
 url: https://github.com/citation-file-format/citation-file-format
-version: "1.2.3"
 license: 
   - "Apache-2.0"
   - "MIT"


### PR DESCRIPTION
Fix #189

**Describe the changes made in this pull request**

- Remove `version` and `date-released` from the `required` array of the root properties object, thereby making them optional

**Instructions to review the pull request**

```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 tests/schema_poc.py -d tests/1.2.0/poc/CITATION.cff -s schema.json  # <- should be quiet
```bash