### PR TITLE
Add optional `description` property to identifiers

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -447,6 +447,9 @@
                         },
                         "value": {
                             "$ref": "#/definitions/doi"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/identifier-description"
                         }
                     },
                     "required": [
@@ -466,6 +469,9 @@
                         },
                         "value": {
                             "$ref": "#/definitions/url"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/identifier-description"
                         }
                     },
                     "required": [
@@ -485,6 +491,9 @@
                         },
                         "value": {
                             "$ref": "#/definitions/swh-identifier"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/identifier-description"
                         }
                     },
                     "required": [
@@ -505,6 +514,9 @@
                         "value": {
                             "minLength": 1,
                             "type": "string"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/identifier-description"
                         }
                     },
                     "required": [
@@ -1708,6 +1720,15 @@
             ],
             "type": "string",
             "pattern": "^swh:1:(snp|rel|rev|dir|cnt):[0-9a-fA-F]{40}$"
+        },
+        "identifier-description": {
+            "description": "A description for a specific identifier value.",
+            "examples": [
+                "The version DOI for this version, which has a relation childOf with the concept DOI specified in the doi field in the root of this file.",
+                "The identifier provided by Archival Repository, which points to this version of the software."
+            ],
+            "type": "string",
+            "minLength": 1
         }
     }
 }

--- a/tests/1.2.0/poc/CITATION.cff
+++ b/tests/1.2.0/poc/CITATION.cff
@@ -38,12 +38,16 @@ date-released: "2021-05-16"
 identifiers:
 - type: doi
   value: "10.0000.1234/ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._[]()\\:;"
+  description: "A pseudo-DOI testing all allowed characters."
 - type: other
   value: some random other identifier
+  description: "A really random, unquoted string with whitespaces in between, which YAML can still handle."
 - type: swh
   value: swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2
+  description: "The Software Heritage identifier pointing to the GPL v3 license text."
 - type: url
   value: https://github.com/citation-file-format/citation-file-format
+  description: "Just any old URL!"
 license-url: http://r3s34archs0ft.com/eula
 message: "If you use this software, cite it using these metadata"
 preferred-citation:


### PR DESCRIPTION
**Related issues**

Fix #181

**Describe the changes made in this pull request**

- Adds an optional field `description` to all identifier properties
- Define `identifier-description` object
- Add test data for new field

**Instructions to review the pull request**


```bash
git clone this repo
git checkout this branch
python3 -m venv env
source env/bin/activate
pip install --upgrade pip setuptools wheel
pip install -r requirements.txt
python3 tests/schema_poc.py -d tests/1.2.0/poc/CITATION.cff -s schema.json  # <- should be quiet
```bash