### PR TITLE
Fix trailing `-` warning in schema.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1261,7 +1261,7 @@
                 },
                 "isbn": {
                     "description": "The ISBN of the work.",
-                    "pattern": "^[0-9- ]{10,17}X?$",
+                    "pattern": "^[0-9\\- ]{10,17}X?$",
                     "type": "string"
                 },
                 "issn": {


### PR DESCRIPTION
Fixes #235.

**Related issues**

Refs: #235

(For autoclosure of issues when PR is merged use `Fixes #<issue-number>` syntax)

**Describe the changes made in this pull request**

Escapes the bare `-` in the ISBN regex.

**Instructions to review the pull request**

Trivial change is on line 1264 of the schema.
