### PR TITLE
same layout everywhere in schema-guide.md

### DIFF
--- a/schema-guide.md
+++ b/schema-guide.md
@@ -603,9 +603,7 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: `object`
-- **required**: `false`
-- **description**: `definitions.entity` has the following properties:
+- **type**: `object` with the following properties:
     - [`address`](#definitionsentityaddress)
     - [`alias`](#definitionsentityalias)
     - [`city`](#definitionsentitycity)
@@ -621,6 +619,8 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
     - [`region`](#definitionsentityregion)
     - [`tel`](#definitionsentitytel)
     - [`website`](#definitionsentitywebsite)
+- **required**: `false`
+- **description**: An entity.
 - **usage**:<br><br>
     ```yaml
     ```
@@ -1386,9 +1386,7 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: `object`
-- **required**: `false`
-- **description**: `definitions.person` has the following properties:
+- **type**: `object` with the following properties:
     - [`address`](#definitionspersonaddress)
     - [`affiliation`](#definitionspersonaffiliation)
     - [`alias`](#definitionspersonalias)
@@ -1405,6 +1403,8 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
     - [`region`](#definitionspersonregion)
     - [`tel`](#definitionspersontel)
     - [`website`](#definitionspersonwebsite)
+- **required**: `false`
+- **description**: A person.
 - **usage**:<br><br>
     ```yaml
     ```
@@ -1446,7 +1446,7 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: - type: [`definitions.city`](#definitionscity)
+- **type**: [`definitions.city`](#definitionscity)
 - **required**: `false`
 - **description**: The person's city.
 - **usage**:<br><br>
@@ -1457,7 +1457,7 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: - type: [`definitions.country`](#definitioncountry)
+- **type**: [`definitions.country`](#definitioncountry)
 - **required**: `false`
 - **description**: The person's country.
 - **usage**:<br><br>
@@ -1468,7 +1468,7 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: - type: [`definitions.email`](#definitionsemail)
+- **type**: [`definitions.email`](#definitionsemail)
 - **required**: `false`
 - **description**: The person's email address.
 - **usage**:<br><br>
@@ -1612,9 +1612,7 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: object
-- **required**: `false`
-- **description**: `definitions.reference` has the following properties:
+- **type**: `object` with the following properties:
     - [`abbreviation`](#definitionsreferenceabbreviation)
     - [`abstract`](#definitionsreferenceabstract)
     - [`authors`](#definitionsreferenceauthors)
@@ -1685,6 +1683,8 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
     - [`volume-title`](#definitionsreferencevolume-title)
     - [`year`](#definitionsreferenceyear)
     - [`year-original`](#definitionsreferenceyear-original)
+- **required**: `false`
+- **description**: A reference.
 - **usage**:<br><br>
     ```yaml
     ```

--- a/schema-guide.md
+++ b/schema-guide.md
@@ -621,71 +621,94 @@ Note to tool implementers: it is necessary to cast YAML date objects to string o
     - [`region`](#definitionsentityregion)
     - [`tel`](#definitionsentitytel)
     - [`website`](#definitionsentitywebsite)
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.address`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.address`](#definitionsaddress).
-
-The entity's address.
+- **type**: See [`definitions.address`](#definitionsaddress).
+- **required**: `false`
+- **description**: The entity's address.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.alias`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.alias`](#definitionsalias).
-
-The entity's alias.
+- **type**: See [`definitions.alias`](#definitionsalias).
+- **required**: `false`
+- **description**: The entity's alias.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.city`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.city`](#definitionscity).
-
-The entity's city.
+- **type**: See [`definitions.city`](#definitionscity).
+- **required**: `false`
+- **description**: The entity's city..
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.country`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.country`](#definitionscountry).
-
-The entity's country.
+- **type**: See [`definitions.country`](#definitionscountry).
+- **required**: `false`
+- **description**: The entity's country.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.date-end`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.date`](#definitionsdate).
-
-The entity's ending date, e.g. when the entity is a conference.
+- **type**: See [`definitions.date`](#definitionsdate).
+- **required**: `false`
+- **description**: The entity's ending date, e.g. when the entity is a conference.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.date-start`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.date`](#definitionsdate).
-
-The entity's starting date, e.g. when the entity is a conference.
+- **type**: See [`definitions.date`](#definitionsdate).
+- **required**: `false`
+- **description**: The entity's starting date, e.g. when the entity is a conference.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.email`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.email`](#definitionsemail).
-
-The entity's email address.
+- **type**: See [`definitions.email`](#definitionsemail).
+- **required**: `false`
+- **description**: The entity's email address.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.fax`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.fax`](#definitionsfax).
-
-The entity's fax number.
-
+- **type**: See [`definitions.fax`](#definitionsfax).
+- **required**: `false`
+- **description**: The entity's fax number.
 - **usage**:<br><br>
     ```yaml
     authors:
@@ -719,34 +742,42 @@ The entity's fax number.
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.orcid`](#definitionsorcid).
-
-The entity's orcid.
+- **type**: See [`definitions.orcid`](#definitionsorcid).
+- **required**: `false`
+- **description**: The entity's orcid.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.post-code`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.post-code`](#definitionspost-code).
-
-The entity's post code.
+- **type**: See [`definitions.post-code`](#definitionspost-code).
+- **required**: `false`
+- **description**: The entity's post code.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.region`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.region`](#definitionsregion).
-
-The entity's region.
+- **type**: See [`definitions.region`](#definitionsregion).
+- **required**: `false`
+- **description**: The entity's region.
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.entity.tel`
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.tel`](#definitionstel).
-
-The entity's telephone number.
-
+- **type**: See [`definitions.tel`](#definitionstel).
+- **required**: `false`
+- **description**: The entity's telephone number.
 - **usage**:<br><br>
     ```yaml
     authors:
@@ -758,10 +789,9 @@ The entity's telephone number.
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-See [`definitions.url`](#definitionsurl).
-
-The entity's website.
-
+- **type**: See [`definitions.url`](#definitionsurl).
+- **required**: `false`
+- **description**: The entity's website.
 - **usage**:<br><br>
     ```yaml
     authors:
@@ -1375,6 +1405,9 @@ The entity's website.
     - [`region`](#definitionspersonregion)
     - [`tel`](#definitionspersontel)
     - [`website`](#definitionspersonwebsite)
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.person.address`
 
@@ -1652,6 +1685,9 @@ The entity's website.
     - [`volume-title`](#definitionsreferencevolume-title)
     - [`year`](#definitionsreferenceyear)
     - [`year-original`](#definitionsreferenceyear-original)
+- **usage**:<br><br>
+    ```yaml
+    ```
 
 ### `definitions.reference.abbreviation`
 
@@ -1677,6 +1713,8 @@ The entity's website.
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
+- **type**: `...`
+- **required**: `false`
 - **description**: The abstract of the work.
     - If the work is a journal paper or other academic work: The abstract of the work.
     - If the work is a film, broadcast or similar: The synopsis of the work.

--- a/schema-guide.md
+++ b/schema-guide.md
@@ -14,8 +14,7 @@ A minimal example of a valid `CITATION.cff` file could look like this:
 
 ```yaml
 authors:
-  -
-    family-names: Druskat
+  - family-names: Druskat
     given-names: Stephan
 cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
@@ -29,19 +28,16 @@ For most software however, it is relatively easy to expand the minimal case with
 ```yaml
 abstract: This is my awesome research software. It does many things.
 authors:
-  -
-    family-names: Druskat
+  - family-names: Druskat
     given-names: Stephan
     orcid: "https://orcid.org/0000-0003-4925-7248"
 cff-version: 1.2.0
 date-released: "2021-07-18"
 identifiers:
-  -
-    description: This is the collection of archived snapshots of all versions of My Research Software
+  - description: This is the collection of archived snapshots of all versions of My Research Software
     type: doi
     value: "10.5281/zenodo.123456"
-  -
-    description: This is the archived snapshot of version 0.11.2 of My Research Software
+  - description: This is the archived snapshot of version 0.11.2 of My Research Software
     type: doi
     value: "10.5281/zenodo.123457"
 keywords:
@@ -62,16 +58,14 @@ you built on.
 
 ```yaml
 authors:
-  -
-    family-names: Druskat
+  - family-names: Druskat
     given-names: Stephan
 cff-version: 1.2.0
 message: If you use this software, please cite it using these metadata.
 title: My Research Software
 references:
   authors:
-    -
-      family-names: Spaaks
+    - family-names: Spaaks
       given-names: Jurriaan H.
   title: The foundation of Research Software
   type: software
@@ -88,16 +82,14 @@ the redirection target. Usually, the `message` also reflects the authors' wishes
 
 ```yaml
 authors:
-  -
-    family-names: Druskat
+  - family-names: Druskat
     given-names: Stephan
 cff-version: 1.2.0
 message: If you use this software, please cite the article from preferred-citation instead of the software.
 title: My Research Software
 preferred-citation:
   authors:
-    -
-      family-names: Druskat
+    - family-names: Druskat
       given-names: Stephan
   title: Software paper about My Research Software
   type: article
@@ -336,13 +328,16 @@ licenses, it is assumed their relationship is OR, not AND.
 
 - **type**: A [`definitions.reference`](#definitionsreference) object.
 - **required**: `false`
-- **description**: ...
+- **description**: The reference that should be cited when citing the work, instead of using the software or dataset metadata in this CITATION.cff file.  
+Note that the principles of [software citation](https://doi.org/10.7717/peerj-cs.86) and [data citation](https://doi.org/10.25490/a97f-egyk) require that 
+software should be cited on the same basis as any other research product such as a paper or a book. 
+Adding a different preferred citation may result in a violation of the respective
+primary principle, "Importance", when others cite this work.
 - **usage**:<br><br>
     ```yaml
     preferred-citation:
       authors:
-        -
-          family-names: Famnames
+        - family-names: Famnames
           given-names: Given Nam E.
       title: Title of the work.
       type: generic
@@ -351,7 +346,33 @@ licenses, it is assumed their relationship is OR, not AND.
 
 ### `references`
 
-Array of [`definitions.reference`](#definitionsreference) objects.
+- **type**: Array of [`definitions.reference`](#definitionsreference) objects.
+- **required**: `false`
+- **description**: Reference(s) to other creative works. Similar to a list of references in a paper, references of the software or dataset may include other software (dependencies), or other research products that the software or dataset builds on, but not work describing the software or dataset.
+- **usage**: See also [`definitions.reference`](#definitionsreference).<br><br>
+    ```yaml
+    references:
+      - type: software
+        authors:
+          - name: "The Dependency Project"
+        title: "Dependency"
+        date-released: 2021-07-26
+        doi: 10.5281/zenodo.x1234567
+        version: 0.13.4
+        repository-code: "https://github.com/dependency-project/dependency"
+      - type: article
+        scope: Cite this paper if you want to reference the general concepts of the software.
+        authors:
+          - family-names: Bielefeld
+            name-particle: von
+            given-names: Arthur
+        title: "Towards a 100% accuracy syntax parser for all languages"
+        year: 2099
+        journal: Journal of Hard Science Fiction
+        volume: 42
+        issue: 13
+        doi: 10.9999/hardscifi-lang.42132
+    ```
 
 ### `repository`
 
@@ -1636,19 +1657,19 @@ The entity's website.
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **type**: `...`
+- **type**: `string`
 - **required**: `false`
-- **description**: ...
+- **description**: The abbreviation of a work.
 - **usage**:<br><br>
     ```yaml
     preferred-citation:
-      abbreviation: ...
+      abbreviation: ABC
       type: generic
     ```
     ```yaml
     references:
-      -
-        abbreviation: ...
+      - 
+        abbreviation: DEF
         type: generic
     ```
 
@@ -1656,19 +1677,19 @@ The entity's website.
 
 `definitions` and its subkeys should not be used directly in `CITATION.cff` files.
 
-- **description**: The abstract of a work.
+- **description**: The abstract of the work.
     - If the work is a journal paper or other academic work: The abstract of the work.
     - If the work is a film, broadcast or similar: The synopsis of the work.
 - **usage**:<br><br>
     ```yaml
     preferred-citation:
-      abstract: ...
+      abstract: "This work describes the software or dataset that should be actually cited. etc."
       type: generic
     ```
     ```yaml
     references:
-      -
-        abstract: ...
+      - 
+        abstract: "This work implements an algorithm that we use in our software. etc."
         type: generic
     ```
 
@@ -1687,8 +1708,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        authors: ...
+      - authors: ...
         type: generic
     ```
 
@@ -1707,8 +1727,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        collection-doi: ...
+      - collection-doi: ...
         type: generic
     ```
 
@@ -1727,8 +1746,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        collection-title: ...
+      - collection-title: ...
         type: generic
     ```
 
@@ -1747,8 +1765,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        collection-type: ...
+      - collection-type: ...
         type: generic
     ```
 
@@ -1767,8 +1784,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        commit: ...
+      - commit: ...
         type: generic
     ```
 
@@ -1787,8 +1803,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        conference: ...
+      - conference: ...
         type: generic
     ```
 
@@ -1802,8 +1817,7 @@ The entity's website.
 - **usage**:<br><br>
     ```yaml
     references:
-      -
-        contact: ...
+      - contact: ...
         type: generic
     ```
     ```yaml
@@ -1827,8 +1841,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        copyright: ...
+      - copyright: ...
         type: generic
     ```
 
@@ -1847,8 +1860,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        data-type: ...
+      - data-type: ...
         type: generic
     ```
 
@@ -1867,8 +1879,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        database-provider: ...
+      - database-provider: ...
         type: generic
     ```
 
@@ -1887,8 +1898,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        database: ...
+      - database: ...
         type: generic
     ```
 
@@ -1907,8 +1917,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        date-accessed: ...
+      - date-accessed: ...
         type: generic
     ```
 
@@ -1927,8 +1936,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        date-downloaded: ...
+      - date-downloaded: ...
         type: generic
     ```
 
@@ -1942,8 +1950,7 @@ The entity's website.
 - **usage**:<br><br>
     ```yaml
     references:
-      -
-        date-published: ...
+      - date-published: ...
         type: generic
     ```
     ```yaml
@@ -1967,8 +1974,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        date-released: ...
+      - date-released: ...
         type: generic
     ```
 
@@ -1987,8 +1993,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        department: ...
+      - department: ...
         type: generic
     ```
 
@@ -2007,8 +2012,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        doi: ...
+      - doi: ...
         type: generic
     ```
 
@@ -2027,8 +2031,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        edition: ...
+      - edition: ...
         type: generic
     ```
 
@@ -2047,8 +2050,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        editors: ...
+      - editors: ...
         type: generic
     ```
 
@@ -2067,8 +2069,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        editors-series: ...
+      - editors-series: ...
         type: generic
     ```
 
@@ -2087,8 +2088,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        end: ...
+      - end: ...
         type: generic
     ```
 
@@ -2107,8 +2107,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        entry: ...
+      - entry: ...
         type: generic
     ```
 
@@ -2127,8 +2126,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        filename: ...
+      - filename: ...
         type: generic
     ```
 
@@ -2147,8 +2145,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        format: ...
+      - format: ...
         type: generic
     ```
 
@@ -2167,8 +2164,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        identifiers: ...
+      - identifiers: ...
         type: generic
     ```
 
@@ -2187,8 +2183,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        institution: ...
+      - institution: ...
         type: generic
     ```
 
@@ -2207,8 +2202,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        isbn: ...
+      - isbn: ...
         type: generic
     ```
 
@@ -2227,8 +2221,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        issn: ...
+      - issn: ...
         type: generic
     ```
 
@@ -2247,8 +2240,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        issue: ...
+      - issue: ...
         type: generic
     ```
 
@@ -2267,8 +2259,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        issue-date: ...
+      - issue-date: ...
         type: generic
     ```
 
@@ -2287,8 +2278,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        issue-title: ...
+      - issue-title: ...
         type: generic
     ```
 
@@ -2307,8 +2297,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        journal: ...
+      - journal: ...
         type: generic
     ```
 
@@ -2327,8 +2316,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        keywords: ...
+      - keywords: ...
         type: generic
     ```
 
@@ -2347,8 +2335,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        languages: ...
+      - languages: ...
         type: generic
     ```
 
@@ -2367,8 +2354,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        license: ...
+      - license: ...
         type: generic
     ```
 
@@ -2387,8 +2373,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        license-url: ...
+      - license-url: ...
         type: generic
     ```
 
@@ -2407,8 +2392,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        loc-end: ...
+      - loc-end: ...
         type: generic
     ```
 
@@ -2427,8 +2411,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        loc-start: ...
+      - loc-start: ...
         type: generic
     ```
 
@@ -2447,8 +2430,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        location: ...
+      - location: ...
         type: generic
     ```
 
@@ -2467,8 +2449,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        medium: ...
+      - medium: ...
         type: generic
     ```
 
@@ -2487,8 +2468,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        month: ...
+      - month: ...
         type: generic
     ```
 
@@ -2507,8 +2487,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        nihmsid: ...
+      - nihmsid: ...
         type: generic
     ```
 
@@ -2527,8 +2506,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        notes: ...
+      - notes: ...
         type: generic
     ```
 
@@ -2547,8 +2525,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        number: ...
+      - number: ...
         type: generic
     ```
 
@@ -2567,8 +2544,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        number-volumes: ...
+      - number-volumes: ...
         type: generic
     ```
 
@@ -2587,8 +2563,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        pages: ...
+      - pages: ...
         type: generic
     ```
 
@@ -2607,8 +2582,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        patent-states: ...
+      - patent-states: ...
         type: generic
     ```
 
@@ -2627,8 +2601,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        pmcid: ...
+      - pmcid: ...
         type: generic
     ```
 
@@ -2647,8 +2620,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        publisher: ...
+      - publisher: ...
         type: generic
     ```
 
@@ -2667,8 +2639,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        recipients: ...
+      - recipients: ...
         type: generic
     ```
 
@@ -2687,8 +2658,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        repository: ...
+      - repository: ...
         type: generic
     ```
 
@@ -2707,8 +2677,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        repository-artifact: ...
+      - repository-artifact: ...
         type: generic
     ```
 
@@ -2727,8 +2696,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        repository-code: ...
+      - repository-code: ...
         type: generic
     ```
 
@@ -2747,8 +2715,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        scope: ...
+      - scope: ...
         type: generic
     ```
 
@@ -2767,8 +2734,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        section: ...
+      - section: ...
         type: generic
     ```
 
@@ -2787,8 +2753,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        senders: ...
+      - senders: ...
         type: generic
     ```
 
@@ -2807,8 +2772,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        start: ...
+      - start: ...
         type: generic
     ```
 
@@ -2827,8 +2791,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        status: ...
+      - status: ...
         type: generic
     ```
 
@@ -2847,8 +2810,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        term: ...
+      - term: ...
         type: generic
     ```
 
@@ -2867,8 +2829,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        thesis-type: ...
+      - thesis-type: ...
         type: generic
     ```
 
@@ -2887,8 +2848,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        title: ...
+      - title: ...
         type: generic
     ```
 
@@ -2907,8 +2867,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        translators: ...
+      - translators: ...
         type: generic
     ```
 
@@ -2926,8 +2885,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
     ```
 
 ### `definitions.reference.url`
@@ -2945,8 +2903,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
         url: ...
     ```
 
@@ -2965,8 +2922,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
         version: ...
     ```
 
@@ -2985,8 +2941,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
         volume: ...
     ```
 
@@ -3005,8 +2960,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
         volume-title: ...
     ```
 
@@ -3025,8 +2979,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
         year: ...
     ```
 
@@ -3045,8 +2998,7 @@ The entity's website.
     ```
     ```yaml
     references:
-      -
-        type: generic
+      - type: generic
         year-original: ...
     ```
 

--- a/schema.json
+++ b/schema.json
@@ -1084,7 +1084,7 @@
             "description": "A reference to a work.",
             "properties": {
                 "abbreviation": {
-                    "description": "The abbreviation of the work.",
+                    "description": "The abbreviation of a work.",
                     "minLength": 1,
                     "type": "string"
                 },
@@ -1727,7 +1727,7 @@
         },
         "preferred-citation": {
             "$ref": "#/definitions/reference",
-            "description": "When citing the work, cite this reference instead."
+            "description": "The reference that should be cited when citing the work, instead of using the software or dataset metadata in this CITATION.cff file."
         },
         "references": {
             "description": "Reference(s) to other creative works.",


### PR DESCRIPTION
**Related issues**

Refs: #240

Includes: PR #250 

**Describe the changes made in this pull request**

This PR adds the same layout for subkeys of entity and person as we already have for the other keys, i.e. like so https://github.com/citation-file-format/citation-file-format/issues/240#issuecomment-886170125.

**Instructions to review the pull request**

Look how `schema-guide.md` from this branch is rendered
