### PR TITLE
Fix schema $id

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://citation-file-format.github.io/1.2.0/schema.json#",
+    "$id": "https://citation-file-format.github.io/1.2.0/schema.json",
     "$schema": "http://json-schema.org/draft-07/schema",
     "additionalProperties": false,
     "definitions": {

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://citation-file-format.github.io/1.2.0/schema",
+    "$id": "https://citation-file-format.github.io/1.2.0/schema.json#",
     "$schema": "http://json-schema.org/draft-07/schema",
     "additionalProperties": false,
     "definitions": {


### PR DESCRIPTION
- See https://github.com/citation-file-format/citation-file-format/issues/190#issuecomment-893512188

**Related issues**

Refs: #190, https://github.com/citation-file-format/citation-file-format.github.io/pull/31

**Describe the changes made in this pull request**

- Appends the `.json` extension to the schema `$id`

**Instructions to review the pull request**

1. Go to https://www.jsonschemavalidator.net/
2. For the schema, use the one from this PR
```json
{
"$ref": "https://raw.githubusercontent.com/citation-file-format/citation-file-format/e5c605351e31e2c681ce1dbbbeb8ec00c6944a96/schema.json"
}
```
3. Play around with valid/invalid "CFF-JSON", e.g.:
```json
{
 "cff-version": "1.3.0"
}
```
```json
{
	"authors": [{
		"alias": "author"
	}],
	"cff-version": "1.2.0",
	"message": "None",
	"title": "TITLE",
	"version": "1.1.21"
}
```