### PR TITLE
Optimize contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,22 +1,20 @@
 # Introduction
 
-**Thank you** for considering to contribute to CFF!
+**Thank you** for considering to contribute to the **Citation File Format (CFF) and its schema**!  
+If you mean to contribute to another part of the Citation File Format project, 
+for example a specific software package for working with CFF files,
+please contribute to the respective repository ([list of repositories in the `citation-file-format` GitHub organization](https://github.com/orgs/citation-file-format/repositories)).
 
 **Please follow these guidelines.** Their purpose is to make both contributing and accepting contributions easier for all parties involved.
 
 There are many **ways to contribute**, e.g.:
 
-- Write blog posts, tutorials, etc. about CFF
-- Review any and all parts of the format and its infrastructure: specifications, libraries, documentation, etc., and submit bug reports, feature requests, suggestions and similar, respectively
+- Tell a friend or colleague about the Citation File Format, or tweet about it
+- Write blog posts, tutorials, etc. about the Citation File Format
+- Review the format and its schema dn documentation
 - Language polish any prose output, including the specifications
-- Create a new, better version of the specifications
-- Create new infrastructure, e.g., improve automated tests or develop a library to read CFF files in a new programming language
-
-Please do not use the issue tracker of any 
-[CFF repository](https://github.com/citation-file-format/citation-file-format/blob/master/README.md#repositories) 
-for user support questions. Instead, if the documentation is not sufficient to
-help you, please submit an issue against the respective repository, detailing
-what in the documentation is missing for you to resolve your issue.
+- Create a new, better version of the schema and specifications
+- Improve automated tests, continuous integration, documentation, etc.
 
 # Ground Rules
 
@@ -24,16 +22,17 @@ Your contribution to CFF is valued, and it should be an enjoyable experience.
 To ensure this, there is the CFF 
 [Code of Conduct](https://github.com/citation-file-format/citation-file-format/blob/master/CODE_OF_CONDUCT.md), which you are required to follow.
 
-Apart from how you communicate with others, some CFF projects may have specific
-technical responsibilities, which are outlined in the project's own guidelines
-for contributing. If you cannot find them, please submit an issue in the
-respective repository, asking for the addition of a `CONTRIBUTING.md`.
+Please always start any contribution that will change the contents of this repository by [creating a new issue](https://github.com/citation-file-format/citation-file-format/issues/new/choose). 
+This way, 
+
+- you can make sure that you don't invest your valuable time in something that may not be merged;
+- we can make sure that your contribution is something that will improve CFF, 
+is in scope, 
+and aligns with the roadmap for the Citation File Format.
 
 # Your First Contribution
 
-If you are unsure where to begin contributing to CFF, you can start by reviewing
-the current specifications, as these are the core of CFF. Additionally, look
-through the 
+If you are unsure where to begin with your contribution to CFF, have a look at the
 [open issues in this repository](https://github.com/citation-file-format/citation-file-format/issues), 
 and see if you can identify one that you would like to work on.
 
@@ -42,35 +41,48 @@ If you have never contributed to an open source project, you may find this tutor
 
 # Getting started
 
-As of now, there is no Contributor License Agreement for CFF, although perhaps
-there should be one.
+This is the workflow for contributions to this repository:
 
-Please **fork the repository** you want to contribute to, and then
-**make the changes in your fork**. Once you are happy and think that
-your changes should be included in the code base of the project, 
-please **note the code of conduct** and **send a pull request**. 
+1. [Create a new issue](https://github.com/citation-file-format/citation-file-format/issues/new/choose) 
+to discuss the changes you want to make with the maintainers and community
+2. Fork the repository
+3. Create a branch in your fork of the repository, based on the `main` branch
+4. Make changes in the new branch in your fork
+5. Take note of the [code of conduct](https://github.com/citation-file-format/citation-file-format/blob/main/CODE_OF_CONDUCT.md)
+6. Create a pull request
+7. Address any comments that have come up during review
+8. If and when your pull request has been merged, you can delete your branch (or the whole fork repository)
 
-There is a collection of test `.cff` files in the `test` directory.
+This workflow is loosely based on GitHub flow, and you can find more information in the [GitHub flow documentation](https://docs.github.com/en/get-started/quickstart/github-flow).
+workflow to collaborate on this repository. 
+
+## Details
+
+There is a collection of test `CITATION.cff` files in the `examples` directory.
 It may be a good idea to add a test if you modify the specification,
 or if you discover a part of the specification which is not covered
-by tests. If you modify anything in the `test` directory, it is
+by tests. If you modify anything in the `tests` or `examples` directory, it is
 advised to run these tests locally on your computer prior to submitting
 a pull request. However, if that's not possible, you still can submit
 the pull request and later check the status of the tests for your
-pull requests on GitHub. Please see `test/README.md` file for further
+pull requests on GitHub. Please see [`examples/README.md`](examples/README.md) file for further
 details about tests and instructions how to run them locally.
+
+<!--
+TODO Include a link to README.dev.md here once it exists! 
+See https://github.com/citation-file-format/citation-file-format/issues/301
+-->
 
 # How to submit an issue
 
 If you find a security vulnerability anywhere, do NOT open an issue. Email *cff-
 security /at\ sdruskat \dot/ net* instead.
 
-Every project/repository should have its own issue template, so that when
+This repository uses issue templates, so that when
 you create a new issue, you can simply fill it in and everything that is
 needed to work on your issue will be there.
 
-If no issue template exists, please create an issue for that instead,
-asking for the addition of an issue template.
+If no issue template exists for your specific case, please use the template for "Any other issue".
 
 # How to suggest a feature or enhancement
 
@@ -78,22 +90,7 @@ See [How to submit an issue](#how-to-submit-an-issue).
 
 # FAQ
 
-- **How do I contribute to project/repository XYZ?**  
-
-Every project should have its own guidelines for contributing. If you cannot
-find one, please open an issue against the respective repository and ask
-for the addition of a `CONTRIBUTING.md`.
-
-- **What should the guidelines to contributing include?**
-
-It should link back to 
-[this repository's README](https://github.com/citation-file-format/citation-file-format/blob/master/README.md), 
-pointing specifically to these guidelines as well as the 
-[code of conduct](https://github.com/citation-file-format/citation-file-format/blob/master/CODE_OF_CONDUCT.md) 
-as well. Other suggestions for good guidelines can be found here:
-https://github.com/nayafia/contributing-template.
-
 - **These guidelines do not address aspect XYZ! What should I do now?**
 
-Please [submit an issue](https://github.com/citation-file-format/citation-file-format/issues) here, 
+Please [submit an issue](https://github.com/citation-file-format/citation-file-format/issues/new/choose), 
 asking for clarification and addition to the guidelines.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ to discuss the changes you want to make with the maintainers and community
 5. Take note of the [code of conduct](https://github.com/citation-file-format/citation-file-format/blob/main/CODE_OF_CONDUCT.md)
 6. Create a pull request
 7. Address any comments that have come up during review
-8. If and when your pull request has been merged, you can delete your branch (or the whole fork repository)
+8. If and when your pull request has been merged, you can delete your branch (or the whole forked repository)
 
 This workflow is loosely based on GitHub flow, and you can find more information in the [GitHub flow documentation](https://docs.github.com/en/get-started/quickstart/github-flow).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Introduction
 
 **Thank you** for considering to contribute to the **Citation File Format (CFF) and its schema**!  
-If you mean to contribute to another part of the Citation File Format project, 
+If you intend to contribute to another part of the Citation File Format project, 
 for example a specific software package for working with CFF files,
 please contribute to the respective repository ([list of repositories in the `citation-file-format` GitHub organization](https://github.com/orgs/citation-file-format/repositories)).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,6 @@ to discuss the changes you want to make with the maintainers and community
 8. If and when your pull request has been merged, you can delete your branch (or the whole fork repository)
 
 This workflow is loosely based on GitHub flow, and you can find more information in the [GitHub flow documentation](https://docs.github.com/en/get-started/quickstart/github-flow).
-workflow to collaborate on this repository. 
 
 ## Details
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ There are many **ways to contribute**, e.g.:
 
 - Tell a friend or colleague about the Citation File Format, or tweet about it
 - Write blog posts, tutorials, etc. about the Citation File Format
-- Review the format and its schema dn documentation
+- Review the format and its schema and documentation
 - Improve wording in any prose output, including the specifications
 - Create a new, better version of the schema and specifications
 - Improve automated tests, continuous integration, documentation, etc.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,11 @@ to discuss the changes you want to make with the maintainers and community
 
 This workflow is loosely based on GitHub flow, and you can find more information in the [GitHub flow documentation](https://docs.github.com/en/get-started/quickstart/github-flow).
 
-## Details
+## Working with examples and tests
 
 There is a collection of test `CITATION.cff` files in the `examples` directory.
 It may be a good idea to add a test if you modify the specification,
-or if you discover a part of the specification which is not covered
+or if you discover a part of the specification that is not covered
 by tests. If you modify anything in the `tests` or `examples` directory, it is
 advised to run these tests locally on your computer prior to submitting
 a pull request. However, if that's not possible, you still can submit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ There are many **ways to contribute**, e.g.:
 - Tell a friend or colleague about the Citation File Format, or tweet about it
 - Write blog posts, tutorials, etc. about the Citation File Format
 - Review the format and its schema dn documentation
-- Language polish any prose output, including the specifications
+- Improve wording in any prose output, including the specifications
 - Create a new, better version of the schema and specifications
 - Improve automated tests, continuous integration, documentation, etc.
 


### PR DESCRIPTION
**Related issues**

- Fix #234
- Fix #169

**Describe the changes made in this pull request**

- Optimize contribution guidelines (#234)
- Describe workflow as an enumerated list based on GitHub flow (#169)
- Remove mentions of how things are done in other repos
- Add note about what to do when people want to contribute to another
repo
- Slim down FAQ
- Mention branch to branch off of (#169)

**Instructions to review the pull request**

- [ ] **Reviewers** to check if all changes are recorded in `CHANGELOG.md` and adapt if neccesary
- [ ] **Reviewers:**
- Read though CONTRIBUTING.md
- Discuss whether we should lock down `main` (I'm personally :+1:)