### PR TITLE
Fix typo and closing code block mark indentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Refs: #ISSUE_NUMBER
 
 **Review checklist**
 
-- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if neccesary.
+- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
 - [ ] Please run tests locally.
 <!-- 
 CONTRIBUTORS: Please replace <do other things> in the snippet below 

--- a/schema-guide.md
+++ b/schema-guide.md
@@ -1963,7 +1963,7 @@ Note that these keys may still not be optimal for, e.g., Icelandic names which d
         region: Renfrewshire
         tel: +12-345-6789098
         website: "https://research-project.org"
-      ```
+    ```
 
 ### `definitions.person.address`
 


### PR DESCRIPTION
**Related issues**

N/A

**Describe the changes made in this pull request**

Fixed the indentation of a closing code mark `` ``` ``

**Instructions to review the pull request**

Search for the stray `` ``` `` in the [initial rendered text](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md). In my [fork](https://github.com/pothitos/citation-file-format/blob/patch-1/schema-guide.md) it has disappeared.

**Review checklist**

- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if neccesary.
- [x] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
