### PR TITLE
Duplicate identifiers[1] in doi field

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -52,6 +52,7 @@ keywords:
   - research software
   - credit
 license: "CC-BY-4.0"
+doi: 10.5281/zenodo.5171937
 references:
   - authors:
       - family-names: Smith


### PR DESCRIPTION
**Related issues**

Fixes #318

**Describe the changes made in this pull request**

- Duplicates the value from `identifiers[1]` in the `doi` field to achieve rendering on GitHub

**Instructions to review the pull request**

- Check CFF file

**Review checklist**

- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
python examples/validator.py -s schema.json -d CITATION.cff
```