### PR TITLE
Add `start` to the field list of `reference`.

### DIFF
--- a/schema-guide.md
+++ b/schema-guide.md
@@ -14,7 +14,7 @@ contains whitespace,
 contains special characters (e.g., any of `:{}[],&*#?|-<>=!%`, or any of `` ` `` and `@` at the beginning),
 consists only of numbers (e.g., is the string `"42"`, not the number `42`),
 or is `"true"`, `"false"`, `"yes"` or `"no"`.
-  
+
 In short: When a string value doesn't behave as expected, try putting it in `"` quotes.
 
 ### Minimal example
@@ -2263,6 +2263,7 @@ Note that these keys may still not be optimal for, e.g., Icelandic names which d
     - [`scope`](#definitionsreferencescope)
     - [`section`](#definitionsreferencesection)
     - [`senders`](#definitionsreferencesenders)
+    - [`start`](#definitionsreferencestart)
     - [`status`](#definitionsreferencestatus)
     - [`term`](#definitionsreferenceterm)
     - [`thesis-type`](#definitionsreferencethesis-type)


### PR DESCRIPTION
In the schema guide, `start` was not listed in the set of fields for `reference`. It was defined though, so this is just a simple addition of a link.

I haven't updated CHANGELOG.md as it is such a minor change and wouldn't match the sorts of other changes in there. Let me know if I wrong about this!

All tests run locally and pass.

**Related issues**

Fixes #352 

(For autoclosure of issues when PR is merged use `Fixes #<issue-number>` syntax)

**Describe the changes made in this pull request**

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
