### PR TITLE
Add example for identification of last stable release to schema guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add example of `identifier.url` pointing to a last stable release before current version to docs (#382)
+
+### Fixed
+
 - Fixed the regular expression for `isbn` (should only affect ISBN10 strings that didn't have any dashes or spaces, whose check digit is `X`). Issue [#323](https://github.com/citation-file-format/citation-file-format/issues/323); PR [#335](https://github.com/citation-file-format/citation-file-format/pull/335); PR [#337](https://github.com/citation-file-format/citation-file-format/pull/337)
 
 

--- a/schema-guide.md
+++ b/schema-guide.md
@@ -1388,6 +1388,12 @@ authors:
         description: The GitHub release URL of the commit tagged with 1.1.0.
     ```
     ```yaml
+    identifiers:
+      - description: "The last stable released version preceding the current development version of the work"
+        type: url
+        value: "https://github.com/citation-file-format/citation-file-format/releases/tag/1.2.0"
+    ```
+    ```yaml
     preferred-citation:
       identifiers:
         - type: other


### PR DESCRIPTION
**Related issues**

Refs: #382

**Describe the changes made in this pull request**

- Add an example for a `url` `identifier` pointing to a stable release of the work

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] Check place and content of documentation change