### PR TITLE
Remove real orcid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace real ORCID with example ORCID from https://orcid.org/1234-5678-9101-1121
+
 ## [1.2.0] - 2021-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ abstract: This is my awesome research software. It does many things.
 authors:
   - family-names: Druskat
     given-names: Stephan
-    orcid: "https://orcid.org/0000-0003-4925-7248"
+    orcid: "https://orcid.org/1234-5678-9101-1121"
   - name: "The Research Software project"
 version: 0.11.2
 date-released: "2021-07-18"

--- a/schema-guide.md
+++ b/schema-guide.md
@@ -39,7 +39,7 @@ abstract: "This is my awesome research software. It does many things."
 authors:
   - family-names: Druskat
     given-names: Stephan
-    orcid: "https://orcid.org/0000-0003-4925-7248"
+    orcid: "https://orcid.org/1234-5678-9101-1121"
 cff-version: 1.2.0
 date-released: "2021-07-18"
 identifiers:
@@ -978,7 +978,7 @@ authors:
         fax: +12-3456-7890
         location: "Lovelace Building, room 0.42"
         name: "The Research Software Project"
-        orcid: "https://orcid.org/0000-0003-4925-7248"
+        orcid: "https://orcid.org/1234-5678-9101-1121"
         post-code: 90210
         region: Renfrewshire
         tel: +12-345-6789098
@@ -1156,7 +1156,7 @@ authors:
     ```yaml
     authors:
       - name: "The Research Software Project"
-        orcid: "https://orcid.org/0000-0003-4925-7248"
+        orcid: "https://orcid.org/1234-5678-9101-1121"
     ```
 
 ### `definitions.entity.post-code`
@@ -1920,7 +1920,7 @@ authors:
     authors:
       - family-names: Druskat
         given-names: Stephan
-        orcid: "https://orcid.org/0000-0003-4925-7248"
+        orcid: "https://orcid.org/1234-5678-9101-1121"
     ```
 
 ### `definitions.person`
@@ -1966,7 +1966,7 @@ Note that these keys may still not be optimal for, e.g., Icelandic names which d
         given-names: Stephan
         name-particle: von
         name-suffix: III
-        orcid: "https://orcid.org/0000-0003-4925-7248"
+        orcid: "https://orcid.org/1234-5678-9101-1121"
         post-code: 90210
         region: Renfrewshire
         tel: +12-345-6789098
@@ -2124,7 +2124,7 @@ Note that these keys may still not be optimal for, e.g., Icelandic names which d
     authors:
       - family-names: Druskat
         given-names: Stephan
-        orcid: "https://orcid.org/0000-0003-4925-7248"
+        orcid: "https://orcid.org/1234-5678-9101-1121"
     ```
 
 ### `definitions.person.post-code`


### PR DESCRIPTION
**Related issues**

I get new records added to my ORCID account every now and then, because examples and templates include my real ORCID 🙄. This is also entirely my fault.

**Describe the changes made in this pull request**

- Replace my ORCID in README and schema guide with the example valid ORCID given at https://orcid.org/1234-5678-9101-1121.

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout remove-real-orcid
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] Search for instances of 0000-0003-4925-7248 (my ORCID) to check that I haven't missed any.
