### PR TITLE
Fix link checking in CI

### DIFF
--- a/.mlc-config.json
+++ b/.mlc-config.json
@@ -9,5 +9,13 @@
         "pattern": "^#"
     }],
     "retryOn429": true,
-    "fallbackRetryDelay": "30s"
+    "fallbackRetryDelay": "30s",
+    "httpHeaders": [
+        {
+          "urls": ["https://docs.github.com/"],
+          "headers": {
+            "Accept-Encoding": "zstd, br, gzip, deflate"
+          }
+        }
+      ]
 }


### PR DESCRIPTION
- Introduce a workaround for link checking failing on docs.github.com URLs, see https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/136#issuecomment-1117148640.

**Related issues**

Fixes #425

**Describe the changes made in this pull request**

- Configure MLC to accept compressed reply enocdings for https://docs.github.com

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout fix-link-checking
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] Check if link checker in CI passes
