### PR TITLE
Drop Python 3.6 tests, add 3.10-3.12 tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
**Related issues**

Fix #441

**Describe the changes made in this pull request**

- Drop testing against Python 3.6 in CI which isn't supported in Ubuntu latest anymore.  
This can be considered an inconsequential change, as it primarily tests whether `jsonschema` can run based on `ruamel.yaml`-loaded YAML.
- Add supported Python versions 3.10-3.12.

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please check if all `testing` jobs succeed in CI run of this PR. This is in lieu of testing locally, which would need separate environments for all supported Python versions.
