### PR TITLE
Minor schema updates

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -377,6 +377,7 @@
             "type": "string"
         },
         "identifier": {
+            "description": "An identifier for a work.",
             "oneOf": [
                 {
                     "additionalProperties": false,
@@ -459,8 +460,7 @@
                     ],
                     "type": "object"
                 }
-            ],
-            "description": "An identifier for a work."
+            ]
         },
         "identifier-description": {
             "description": "A description for a specific identifier value.",
@@ -1058,6 +1058,7 @@
             "type": "object"
         },
         "post-code": {
+            "description": "A post code.",
             "oneOf": [
                 {
                     "minLength": 1,
@@ -1066,8 +1067,7 @@
                 {
                     "type": "number"
                 }
-            ],
-            "description": "A post code."
+            ]
         },
         "reference": {
             "additionalProperties": false,
@@ -1218,6 +1218,7 @@
                     "uniqueItems": true
                 },
                 "end": {
+                    "description": "The end page of the work.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1226,8 +1227,7 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The end page of the work."
+                    ]
                 },
                 "entry": {
                     "description": "An entry in the collection that constitutes the work.",
@@ -1268,6 +1268,7 @@
                     "type": "string"
                 },
                 "issue": {
+                    "description": "The issue of a periodical in which a work appeared.",
                     "oneOf": [
                         {
                             "minLength": 1,
@@ -1276,8 +1277,7 @@
                         {
                             "type": "number"
                         }
-                    ],
-                    "description": "The issue of a periodical in which a work appeared."
+                    ]
                 },
                 "issue-date": {
                     "description": "The publication date of the issue of a periodical in which a work appeared.",
@@ -1324,6 +1324,7 @@
                     "description": "The URL of the license text under which the work is licensed (only for non-standard licenses not included in the SPDX License List)."
                 },
                 "loc-end": {
+                    "description": "The line of code in the file where the work ends.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1332,10 +1333,10 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The line of code in the file where the work ends."
+                    ]
                 },
                 "loc-start": {
+                    "description": "The line of code in the file where the work starts.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1344,8 +1345,7 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The line of code in the file where the work starts."
+                    ]
                 },
                 "location": {
                     "$ref": "#/$defs/entity",
@@ -1357,6 +1357,7 @@
                     "type": "string"
                 },
                 "month": {
+                    "description": "The month in which a work has been published.",
                     "oneOf": [
                         {
                             "maximum": 12,
@@ -1380,8 +1381,7 @@
                             ],
                             "type": "string"
                         }
-                    ],
-                    "description": "The month in which a work has been published."
+                    ]
                 },
                 "nihmsid": {
                     "description": "The NIHMSID of a work.",
@@ -1394,6 +1394,7 @@
                     "type": "string"
                 },
                 "number": {
+                    "description": "The accession number for a work.",
                     "oneOf": [
                         {
                             "minLength": 1,
@@ -1402,10 +1403,10 @@
                         {
                             "type": "number"
                         }
-                    ],
-                    "description": "The accession number for a work."
+                    ]
                 },
                 "number-volumes": {
+                    "description": "The number of volumes making up the collection in which the work has been published.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1414,10 +1415,10 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The number of volumes making up the collection in which the work has been published."
+                    ]
                 },
                 "pages": {
+                    "description": "The number of pages of the work.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1426,8 +1427,7 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The number of pages of the work."
+                    ]
                 },
                 "patent-states": {
                     "description": "The states for which a patent is granted.",
@@ -1482,6 +1482,7 @@
                     "type": "string"
                 },
                 "section": {
+                    "description": "The section of a work that is referenced.",
                     "oneOf": [
                         {
                             "minLength": 1,
@@ -1490,8 +1491,7 @@
                         {
                             "type": "number"
                         }
-                    ],
-                    "description": "The section of a work that is referenced."
+                    ]
                 },
                 "senders": {
                     "description": "The sender(s) of a personal communication.",
@@ -1510,6 +1510,7 @@
                     "uniqueItems": true
                 },
                 "start": {
+                    "description": "The start page of the work.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1518,8 +1519,7 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The start page of the work."
+                    ]
                 },
                 "status": {
                     "description": "The publication status of the work.",
@@ -1626,6 +1626,7 @@
                     "description": "The version of the work."
                 },
                 "volume": {
+                    "description": "The volume of the periodical in which a work appeared.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1634,8 +1635,7 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The volume of the periodical in which a work appeared."
+                    ]
                 },
                 "volume-title": {
                     "description": "The title of the volume in which the work appeared.",
@@ -1643,6 +1643,7 @@
                     "type": "string"
                 },
                 "year": {
+                    "description": "The year in which a work has been published.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1651,10 +1652,10 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The year in which a work has been published."
+                    ]
                 },
                 "year-original": {
+                    "description": "The year of the original publication.",
                     "oneOf": [
                         {
                             "type": "integer"
@@ -1663,8 +1664,7 @@
                             "minLength": 1,
                             "type": "string"
                         }
-                    ],
-                    "description": "The year of the original publication."
+                    ]
                 }
             },
             "required": [

--- a/schema.json
+++ b/schema.json
@@ -1,8 +1,5 @@
 {
-    "$id": "https://citation-file-format.github.io/1.2.0/schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema",
-    "additionalProperties": false,
-    "definitions": {
+    "$defs": {
         "address": {
             "description": "An address.",
             "minLength": 1,
@@ -307,35 +304,35 @@
             "description": "An entity, i.e., an institution, team, research group, company, conference, etc., as opposed to a single natural person.",
             "properties": {
                 "address": {
-                    "$ref": "#/definitions/address",
+                    "$ref": "#/$defs/address",
                     "description": "The entity's address."
                 },
                 "alias": {
-                    "$ref": "#/definitions/alias",
+                    "$ref": "#/$defs/alias",
                     "description": "The entity's alias."
                 },
                 "city": {
-                    "$ref": "#/definitions/city",
+                    "$ref": "#/$defs/city",
                     "description": "The entity's city."
                 },
                 "country": {
-                    "$ref": "#/definitions/country",
+                    "$ref": "#/$defs/country",
                     "description": "The entity's country."
                 },
                 "date-end": {
-                    "$ref": "#/definitions/date",
+                    "$ref": "#/$defs/date",
                     "description": "The entity's ending date, e.g., when the entity is a conference."
                 },
                 "date-start": {
-                    "$ref": "#/definitions/date",
+                    "$ref": "#/$defs/date",
                     "description": "The entity's starting date, e.g., when the entity is a conference."
                 },
                 "email": {
-                    "$ref": "#/definitions/email",
+                    "$ref": "#/$defs/email",
                     "description": "The entity's email address."
                 },
                 "fax": {
-                    "$ref": "#/definitions/fax",
+                    "$ref": "#/$defs/fax",
                     "description": "The entity's fax number."
                 },
                 "location": {
@@ -349,23 +346,23 @@
                     "type": "string"
                 },
                 "orcid": {
-                    "$ref": "#/definitions/orcid",
+                    "$ref": "#/$defs/orcid",
                     "description": "The entity's orcid."
                 },
                 "post-code": {
-                    "$ref": "#/definitions/post-code",
+                    "$ref": "#/$defs/post-code",
                     "description": "The entity's post code."
                 },
                 "region": {
-                    "$ref": "#/definitions/region",
+                    "$ref": "#/$defs/region",
                     "description": "The entity's region."
                 },
                 "tel": {
-                    "$ref": "#/definitions/tel",
+                    "$ref": "#/$defs/tel",
                     "description": "The entity's telephone number."
                 },
                 "website": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The entity's website."
                 }
             },
@@ -385,14 +382,14 @@
                     "additionalProperties": false,
                     "properties": {
                         "description": {
-                            "$ref": "#/definitions/identifier-description"
+                            "$ref": "#/$defs/identifier-description"
                         },
                         "type": {
                             "const": "doi",
                             "type": "string"
                         },
                         "value": {
-                            "$ref": "#/definitions/doi"
+                            "$ref": "#/$defs/doi"
                         }
                     },
                     "required": [
@@ -405,14 +402,14 @@
                     "additionalProperties": false,
                     "properties": {
                         "description": {
-                            "$ref": "#/definitions/identifier-description"
+                            "$ref": "#/$defs/identifier-description"
                         },
                         "type": {
                             "const": "url",
                             "type": "string"
                         },
                         "value": {
-                            "$ref": "#/definitions/url"
+                            "$ref": "#/$defs/url"
                         }
                     },
                     "required": [
@@ -425,14 +422,14 @@
                     "additionalProperties": false,
                     "properties": {
                         "description": {
-                            "$ref": "#/definitions/identifier-description"
+                            "$ref": "#/$defs/identifier-description"
                         },
                         "type": {
                             "const": "swh",
                             "type": "string"
                         },
                         "value": {
-                            "$ref": "#/definitions/swh-identifier"
+                            "$ref": "#/$defs/swh-identifier"
                         }
                     },
                     "required": [
@@ -445,7 +442,7 @@
                     "additionalProperties": false,
                     "properties": {
                         "description": {
-                            "$ref": "#/definitions/identifier-description"
+                            "$ref": "#/$defs/identifier-description"
                         },
                         "type": {
                             "const": "other",
@@ -478,7 +475,7 @@
             "description": "An SPDX license identifier.",
             "oneOf": [
                 {
-                    "$ref": "#/definitions/license-enum",
+                    "$ref": "#/$defs/license-enum",
                     "examples": [
                         "Apache-2.0",
                         "MIT"
@@ -497,7 +494,7 @@
                         ]
                     ],
                     "items": {
-                        "$ref": "#/definitions/license-enum"
+                        "$ref": "#/$defs/license-enum"
                     },
                     "minItems": 1,
                     "type": "array",
@@ -982,7 +979,7 @@
             "description": "A person.",
             "properties": {
                 "address": {
-                    "$ref": "#/definitions/address",
+                    "$ref": "#/$defs/address",
                     "description": "The person's address."
                 },
                 "affiliation": {
@@ -991,19 +988,19 @@
                     "type": "string"
                 },
                 "alias": {
-                    "$ref": "#/definitions/alias",
+                    "$ref": "#/$defs/alias",
                     "description": "The person's alias."
                 },
                 "city": {
-                    "$ref": "#/definitions/city",
+                    "$ref": "#/$defs/city",
                     "description": "The person's city."
                 },
                 "country": {
-                    "$ref": "#/definitions/country",
+                    "$ref": "#/$defs/country",
                     "description": "The person's country."
                 },
                 "email": {
-                    "$ref": "#/definitions/email",
+                    "$ref": "#/$defs/email",
                     "description": "The person's email address."
                 },
                 "family-names": {
@@ -1012,7 +1009,7 @@
                     "type": "string"
                 },
                 "fax": {
-                    "$ref": "#/definitions/fax",
+                    "$ref": "#/$defs/fax",
                     "description": "The person's fax number."
                 },
                 "given-names": {
@@ -1038,23 +1035,23 @@
                     "type": "string"
                 },
                 "orcid": {
-                    "$ref": "#/definitions/orcid",
+                    "$ref": "#/$defs/orcid",
                     "description": "The person's ORCID."
                 },
                 "post-code": {
-                    "$ref": "#/definitions/post-code",
+                    "$ref": "#/$defs/post-code",
                     "description": "The person's post-code."
                 },
                 "region": {
-                    "$ref": "#/definitions/region",
+                    "$ref": "#/$defs/region",
                     "description": "The person's region."
                 },
                 "tel": {
-                    "$ref": "#/definitions/tel",
+                    "$ref": "#/$defs/tel",
                     "description": "The person's phone number."
                 },
                 "website": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The person's website."
                 }
             },
@@ -1091,10 +1088,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             },
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             }
                         ]
                     },
@@ -1103,7 +1100,7 @@
                     "uniqueItems": true
                 },
                 "collection-doi": {
-                    "$ref": "#/definitions/doi",
+                    "$ref": "#/$defs/doi",
                     "description": "The DOI of a collection containing the work."
                 },
                 "collection-title": {
@@ -1117,10 +1114,10 @@
                     "type": "string"
                 },
                 "commit": {
-                    "$ref": "#/definitions/commit"
+                    "$ref": "#/$defs/commit"
                 },
                 "conference": {
-                    "$ref": "#/definitions/entity",
+                    "$ref": "#/$defs/entity",
                     "description": "The conference where the work was presented."
                 },
                 "contact": {
@@ -1128,10 +1125,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             },
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             }
                         ]
                     },
@@ -1155,23 +1152,23 @@
                     "type": "string"
                 },
                 "database-provider": {
-                    "$ref": "#/definitions/entity",
+                    "$ref": "#/$defs/entity",
                     "description": "The provider of the database where a work was accessed/is stored."
                 },
                 "date-accessed": {
-                    "$ref": "#/definitions/date",
+                    "$ref": "#/$defs/date",
                     "description": "The date the work was accessed."
                 },
                 "date-downloaded": {
-                    "$ref": "#/definitions/date",
+                    "$ref": "#/$defs/date",
                     "description": "The date the work has been downloaded."
                 },
                 "date-published": {
-                    "$ref": "#/definitions/date",
+                    "$ref": "#/$defs/date",
                     "description": "The date the work has been published."
                 },
                 "date-released": {
-                    "$ref": "#/definitions/date",
+                    "$ref": "#/$defs/date",
                     "description": "The date the work has been released."
                 },
                 "department": {
@@ -1180,7 +1177,7 @@
                     "type": "string"
                 },
                 "doi": {
-                    "$ref": "#/definitions/doi",
+                    "$ref": "#/$defs/doi",
                     "description": "The DOI of the work."
                 },
                 "edition": {
@@ -1193,10 +1190,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             },
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             }
                         ]
                     },
@@ -1209,10 +1206,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             },
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             }
                         ]
                     },
@@ -1250,14 +1247,14 @@
                 "identifiers": {
                     "description": "The identifier(s) of the work.",
                     "items": {
-                        "$ref": "#/definitions/identifier"
+                        "$ref": "#/$defs/identifier"
                     },
                     "minItems": 1,
                     "type": "array",
                     "uniqueItems": true
                 },
                 "institution": {
-                    "$ref": "#/definitions/entity",
+                    "$ref": "#/$defs/entity",
                     "description": "The institution where a work has been produced or published."
                 },
                 "isbn": {
@@ -1320,10 +1317,10 @@
                     "uniqueItems": true
                 },
                 "license": {
-                    "$ref": "#/definitions/license"
+                    "$ref": "#/$defs/license"
                 },
                 "license-url": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The URL of the license text under which the work is licensed (only for non-standard licenses not included in the SPDX License List)."
                 },
                 "loc-end": {
@@ -1351,7 +1348,7 @@
                     "description": "The line of code in the file where the work starts."
                 },
                 "location": {
-                    "$ref": "#/definitions/entity",
+                    "$ref": "#/$defs/entity",
                     "description": "The location of the work."
                 },
                 "medium": {
@@ -1448,7 +1445,7 @@
                     "type": "string"
                 },
                 "publisher": {
-                    "$ref": "#/definitions/entity",
+                    "$ref": "#/$defs/entity",
                     "description": "The publisher who has published the work."
                 },
                 "recipients": {
@@ -1456,10 +1453,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             },
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             }
                         ]
                     },
@@ -1468,15 +1465,15 @@
                     "uniqueItems": true
                 },
                 "repository": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The URL of the work in a repository (when the repository is neither a source code repository nor a build artifact repository)."
                 },
                 "repository-artifact": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The URL of the work in a build artifact/binary repository."
                 },
                 "repository-code": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The URL of the work in a source code repository."
                 },
                 "scope": {
@@ -1501,10 +1498,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             },
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             }
                         ]
                     },
@@ -1556,10 +1553,10 @@
                     "items": {
                         "oneOf": [
                             {
-                                "$ref": "#/definitions/entity"
+                                "$ref": "#/$defs/entity"
                             },
                             {
-                                "$ref": "#/definitions/person"
+                                "$ref": "#/$defs/person"
                             }
                         ]
                     },
@@ -1621,11 +1618,11 @@
                     "type": "string"
                 },
                 "url": {
-                    "$ref": "#/definitions/url",
+                    "$ref": "#/$defs/url",
                     "description": "The URL of the work."
                 },
                 "version": {
-                    "$ref": "#/definitions/version",
+                    "$ref": "#/$defs/version",
                     "description": "The version of the work."
                 },
                 "volume": {
@@ -1717,6 +1714,9 @@
             ]
         }
     },
+    "$id": "https://citation-file-format.github.io/1.2.0/schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": false,
     "description": "A file with citation metadata for software or datasets.",
     "properties": {
         "abstract": {
@@ -1729,10 +1729,10 @@
             "items": {
                 "oneOf": [
                     {
-                        "$ref": "#/definitions/person"
+                        "$ref": "#/$defs/person"
                     },
                     {
-                        "$ref": "#/definitions/entity"
+                        "$ref": "#/$defs/entity"
                     }
                 ]
             },
@@ -1749,17 +1749,17 @@
             "type": "string"
         },
         "commit": {
-            "$ref": "#/definitions/commit"
+            "$ref": "#/$defs/commit"
         },
         "contact": {
             "description": "The contact person, group, company, etc. for the software or dataset.",
             "items": {
                 "oneOf": [
                     {
-                        "$ref": "#/definitions/person"
+                        "$ref": "#/$defs/person"
                     },
                     {
-                        "$ref": "#/definitions/entity"
+                        "$ref": "#/$defs/entity"
                     }
                 ]
             },
@@ -1772,10 +1772,10 @@
             "items": {
                 "oneOf": [
                     {
-                        "$ref": "#/definitions/person"
+                        "$ref": "#/$defs/person"
                     },
                     {
-                        "$ref": "#/definitions/entity"
+                        "$ref": "#/$defs/entity"
                     }
                 ]
             },
@@ -1784,16 +1784,16 @@
             "uniqueItems": true
         },
         "date-released": {
-            "$ref": "#/definitions/date",
+            "$ref": "#/$defs/date",
             "description": "The date the work has been released."
         },
         "doi": {
-            "$ref": "#/definitions/doi"
+            "$ref": "#/$defs/doi"
         },
         "identifiers": {
             "description": "The identifiers of the software or dataset.",
             "items": {
-                "$ref": "#/definitions/identifier"
+                "$ref": "#/$defs/identifier"
             },
             "minItems": 1,
             "type": "array",
@@ -1810,10 +1810,10 @@
             "uniqueItems": true
         },
         "license": {
-            "$ref": "#/definitions/license"
+            "$ref": "#/$defs/license"
         },
         "license-url": {
-            "$ref": "#/definitions/url",
+            "$ref": "#/$defs/url",
             "description": "The URL of the license text under which the software or dataset is licensed (only for non-standard licenses not included in the SPDX License List)."
         },
         "message": {
@@ -1828,20 +1828,20 @@
             "type": "string"
         },
         "preferred-citation": {
-            "$ref": "#/definitions/reference",
+            "$ref": "#/$defs/reference",
             "description": "A reference to another work that should be cited instead of the software or dataset itself."
         },
         "references": {
             "description": "Reference(s) to other creative works.",
             "items": {
-                "$ref": "#/definitions/reference"
+                "$ref": "#/$defs/reference"
             },
             "minItems": 1,
             "type": "array",
             "uniqueItems": true
         },
         "repository": {
-            "$ref": "#/definitions/url",
+            "$ref": "#/$defs/url",
             "description": "The URL of the software or dataset in a repository (when the repository is neither a source code repository nor a build artifact repository).",
             "examples": [
                 "https://edoc.hu-berlin.de/handle/18452/23016",
@@ -1849,11 +1849,11 @@
             ]
         },
         "repository-artifact": {
-            "$ref": "#/definitions/url",
+            "$ref": "#/$defs/url",
             "description": "The URL of the software in a build artifact/binary repository."
         },
         "repository-code": {
-            "$ref": "#/definitions/url",
+            "$ref": "#/$defs/url",
             "description": "The URL of the software or dataset in a source code repository."
         },
         "title": {
@@ -1871,11 +1871,11 @@
             "type": "string"
         },
         "url": {
-            "$ref": "#/definitions/url",
+            "$ref": "#/$defs/url",
             "description": "The URL of a landing page/website for the software or dataset."
         },
         "version": {
-            "$ref": "#/definitions/version",
+            "$ref": "#/$defs/version",
             "description": "The version of the software or dataset."
         }
     },

--- a/schema.json
+++ b/schema.json
@@ -380,7 +380,7 @@
             "type": "string"
         },
         "identifier": {
-            "anyOf": [
+            "oneOf": [
                 {
                     "additionalProperties": false,
                     "properties": {
@@ -1061,7 +1061,7 @@
             "type": "object"
         },
         "post-code": {
-            "anyOf": [
+            "oneOf": [
                 {
                     "minLength": 1,
                     "type": "string"
@@ -1089,7 +1089,7 @@
                 "authors": {
                     "description": "The author(s) of a work.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/person"
                             },
@@ -1126,7 +1126,7 @@
                 "contact": {
                     "description": "The contact person, group, company, etc. for a work.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/person"
                             },
@@ -1191,7 +1191,7 @@
                 "editors": {
                     "description": "The editor(s) of a work.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/person"
                             },
@@ -1207,7 +1207,7 @@
                 "editors-series": {
                     "description": "The editor(s) of a series in which a work has been published.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/person"
                             },
@@ -1221,7 +1221,7 @@
                     "uniqueItems": true
                 },
                 "end": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1271,7 +1271,7 @@
                     "type": "string"
                 },
                 "issue": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "minLength": 1,
                             "type": "string"
@@ -1327,7 +1327,7 @@
                     "description": "The URL of the license text under which the work is licensed (only for non-standard licenses not included in the SPDX License List)."
                 },
                 "loc-end": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1339,7 +1339,7 @@
                     "description": "The line of code in the file where the work ends."
                 },
                 "loc-start": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1360,7 +1360,7 @@
                     "type": "string"
                 },
                 "month": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "maximum": 12,
                             "minimum": 1,
@@ -1397,7 +1397,7 @@
                     "type": "string"
                 },
                 "number": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "minLength": 1,
                             "type": "string"
@@ -1409,7 +1409,7 @@
                     "description": "The accession number for a work."
                 },
                 "number-volumes": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1421,7 +1421,7 @@
                     "description": "The number of volumes making up the collection in which the work has been published."
                 },
                 "pages": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1454,7 +1454,7 @@
                 "recipients": {
                     "description": "The recipient(s) of a personal communication.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/entity"
                             },
@@ -1485,7 +1485,7 @@
                     "type": "string"
                 },
                 "section": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "minLength": 1,
                             "type": "string"
@@ -1499,7 +1499,7 @@
                 "senders": {
                     "description": "The sender(s) of a personal communication.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/entity"
                             },
@@ -1513,7 +1513,7 @@
                     "uniqueItems": true
                 },
                 "start": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1554,7 +1554,7 @@
                 "translators": {
                     "description": "The translator(s) of a work.",
                     "items": {
-                        "anyOf": [
+                        "oneOf": [
                             {
                                 "$ref": "#/definitions/entity"
                             },
@@ -1629,7 +1629,7 @@
                     "description": "The version of the work."
                 },
                 "volume": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1646,7 +1646,7 @@
                     "type": "string"
                 },
                 "year": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1658,7 +1658,7 @@
                     "description": "The year in which a work has been published."
                 },
                 "year-original": {
-                    "anyOf": [
+                    "oneOf": [
                         {
                             "type": "integer"
                         },
@@ -1706,7 +1706,7 @@
             "type": "string"
         },
         "version": {
-            "anyOf": [
+            "oneOf": [
                 {
                     "minLength": 1,
                     "type": "string"
@@ -1727,7 +1727,7 @@
         "authors": {
             "description": "The author(s) of the software or dataset.",
             "items": {
-                "anyOf": [
+                "oneOf": [
                     {
                         "$ref": "#/definitions/person"
                     },
@@ -1754,7 +1754,7 @@
         "contact": {
             "description": "The contact person, group, company, etc. for the software or dataset.",
             "items": {
-                "anyOf": [
+                "oneOf": [
                     {
                         "$ref": "#/definitions/person"
                     },
@@ -1770,7 +1770,7 @@
         "contributors": {
             "description": "The contributor(s) to a work.",
             "items": {
-                "anyOf": [
+                "oneOf": [
                     {
                         "$ref": "#/definitions/person"
                     },

--- a/schema.json
+++ b/schema.json
@@ -388,9 +388,7 @@
                             "$ref": "#/definitions/identifier-description"
                         },
                         "type": {
-                            "enum": [
-                                "doi"
-                            ],
+                            "const": "doi",
                             "type": "string"
                         },
                         "value": {
@@ -410,9 +408,7 @@
                             "$ref": "#/definitions/identifier-description"
                         },
                         "type": {
-                            "enum": [
-                                "url"
-                            ],
+                            "const": "url",
                             "type": "string"
                         },
                         "value": {
@@ -432,9 +428,7 @@
                             "$ref": "#/definitions/identifier-description"
                         },
                         "type": {
-                            "enum": [
-                                "swh"
-                            ],
+                            "const": "swh",
                             "type": "string"
                         },
                         "value": {
@@ -454,9 +448,7 @@
                             "$ref": "#/definitions/identifier-description"
                         },
                         "type": {
-                            "enum": [
-                                "other"
-                            ],
+                            "const": "other",
                             "type": "string"
                         },
                         "value": {


### PR DESCRIPTION
**Related issues**

Refs: N/A

**Describe the changes made in this pull request**

This PR updates some minor schema parts, e.g.

1. I replaced `anyOf` with `oneOf`, because we don't have cases where we want to match more than 1 subschema simultaneously
2. I replaced singular value `enum`s with just a `const`
3. I replaced `definitions` with `$defs` as per the recommended practice (`$defs` was introduced in JSONSchema draft 2019-09 BTW, and we need draft 2019-09 if we want to have extensible subschemas, for example an item in `contributors` that extends `person` in PR #463)

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
