### PR TITLE
typo in definitions link

### DIFF
--- a/schema-guide.md
+++ b/schema-guide.md
@@ -2027,7 +2027,7 @@ Note that these keys may still not be optimal for, e.g., Icelandic names which d
 
 ### `definitions.person.country`
 
-- **type**: [`definitions.country`](#definitioncountry)
+- **type**: [`definitions.country`](#definitionscountry)
 - **required**: `false`
 - **description**: The person's country.
 - **usage**:<br><br>


### PR DESCRIPTION
**Related issues**

Refs:
 
- N/A

**Describe the changes made in this pull request**

Fixes broken link to `definitions.country`

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
