### PR TITLE
Remove uniqueness requirement on authors and other persons

### DIFF
--- a/examples/1.2.0/fail/nonunique-authors/CITATION.cff
+++ b/examples/1.2.0/fail/nonunique-authors/CITATION.cff
@@ -1,0 +1,6 @@
+cff-version: 1.2.0
+authors:
+- alias: jspaaks
+- alias: jspaaks
+message: The message
+title: The title

--- a/examples/1.2.0/fail/nonunique-contact/CITATION.cff
+++ b/examples/1.2.0/fail/nonunique-contact/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+authors:
+- name: The team
+contact:
+- alias: jspaaks
+- alias: jspaaks
+message: The message
+title: The title

--- a/examples/1.2.0/fail/nonunique-contributors/CITATION.cff
+++ b/examples/1.2.0/fail/nonunique-contributors/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+authors:
+- name: The team
+contributors:
+- alias: jspaaks
+- alias: jspaaks
+message: The message
+title: The title

--- a/examples/1.3.0/pass/nonunique-authors/CITATION.cff
+++ b/examples/1.3.0/pass/nonunique-authors/CITATION.cff
@@ -1,0 +1,6 @@
+cff-version: 1.3.0
+authors:
+- alias: jspaaks
+- alias: jspaaks
+message: The message
+title: The title

--- a/examples/1.3.0/pass/nonunique-contact/CITATION.cff
+++ b/examples/1.3.0/pass/nonunique-contact/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.3.0
+authors:
+- name: The team
+contact:
+- alias: jspaaks
+- alias: jspaaks
+message: The message
+title: The title

--- a/examples/1.3.0/pass/nonunique-contributors/CITATION.cff
+++ b/examples/1.3.0/pass/nonunique-contributors/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.3.0
+authors:
+- name: The team
+contributors:
+- alias: jspaaks
+- alias: jspaaks
+message: The message
+title: The title

--- a/schema.json
+++ b/schema.json
@@ -1297,7 +1297,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "collection-doi": {
                     "$ref": "#/$defs/doi",
@@ -1332,7 +1332,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "copyright": {
                     "$ref": "#/$defs/strictish-string",
@@ -1392,7 +1392,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "editors-series": {
                     "description": "The editor(s) of a series in which a work has been published.",
@@ -1408,7 +1408,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "end": {
                     "description": "The end page of the work.",
@@ -1637,7 +1637,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "repository": {
                     "$ref": "#/$defs/url",
@@ -1680,7 +1680,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "start": {
                     "description": "The start page of the work.",
@@ -1731,7 +1731,7 @@
                     },
                     "minItems": 1,
                     "type": "array",
-                    "uniqueItems": true
+                    "uniqueItems": false
                 },
                 "type": {
                     "description": "The type of the work.",
@@ -1905,7 +1905,7 @@
             },
             "minItems": 1,
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": false
         },
         "cff-version": {
             "description": "The version of CFF used for providing the citation metadata.",
@@ -1932,7 +1932,7 @@
             },
             "minItems": 1,
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": false
         },
         "contributors": {
             "description": "The contributor(s) to a work.",
@@ -1948,7 +1948,7 @@
             },
             "minItems": 1,
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": false
         },
         "date-released": {
             "$ref": "#/$defs/date",


### PR DESCRIPTION
**Related issues**

Refs:

- #472

**Describe the changes made in this pull request**

This PR removes the `uniqueItems` requirement on all usages of the `person` definition:

1. `references.authors`
2. `references.contact`
3. `references.editors`
4. `references.editors-series`
5. `references.recipients`
6. `references.senders`
7. `references.translators`
8. `authors`
9. `contact`
10. `contributors`


TODO 

1. ~~Needs tests~~ _Added_
2. ~~Check guide text~~ _Doesn't mention uniquess AFAICT_

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
