### PR TITLE
Add strictish-string in index of definitions

### DIFF
--- a/schema-guide.md
+++ b/schema-guide.md
@@ -565,6 +565,7 @@ authors:
 - [`definitions.post-code`](#definitionspost-code)
 - [`definitions.reference`](#definitionsreference) (object)
 - [`definitions.region`](#definitionsregion)
+- [`definitions.strictish-string`](#definitionsstrictish-string)
 - [`definitions.swh-identifier`](#definitionsswh-identifier)
 - [`definitions.tel`](#definitionstel)
 - [`definitions.url`](#definitionsurl)


### PR DESCRIPTION
**Related issues**

Refs:

- N/A

**Describe the changes made in this pull request**

This PR adds an entry for `strictish-string` in the index of `$defs` in `schema-guide.md`.

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
