### PR TITLE
changed link checker workflow trigger from push to manual or scheduled

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,6 +1,10 @@
 name: links
 
-on: push
+on: 
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '17 3 * * *'  
 
 permissions:
   contents: read


### PR DESCRIPTION
**Related issues**

Refs: 
- N/A

**Describe the changes made in this pull request**

This PR changes the triggering event for running the markdown link checker from just `push` to one of `workflow_dispatch` (i.e. manual trigger) or `scheduled`. Hopefully this will help avoid 429 errors.

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
