### PR TITLE
Update Code of Conduct contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update example testing to use cffconvert 2.0.0 (or newer) validation
 - Update Python versions run in CI to remove end-of-life versions and add newer releases
 - Replace real ORCID with example ORCID from https://orcid.org/1234-5678-9101-1121
+- Provide contact details for the Code of Conduct Committee in the CoC document
 
 ## [1.2.0] - 2021-05-31
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at *cff-coc /at\ sdruskat \dot/ net*. All
+reported by contacting the [Code of Conduct Committee](#code-of-conduct-committee). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
@@ -62,6 +62,15 @@ Further details of specific enforcement policies may be posted separately.
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's maintenance team.
+
+### Code of Conduct Committee
+
+The current Code of Conduct Committee consists of:
+
+- Neil Chue Hong ([N.ChueHong@epcc.ed.ac.uk](mailto:N.ChueHong@epcc.ed.ac.uk))
+- Robert Haines ([robert.haines@manchester.ac.uk](mailto:robert.haines@manchester.ac.uk))
+
+You may contact members individually or collectively. 
 
 ## Attribution
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -70,7 +70,9 @@ The current Code of Conduct Committee consists of:
 - Neil Chue Hong ([N.ChueHong@epcc.ed.ac.uk](mailto:N.ChueHong@epcc.ed.ac.uk))
 - Robert Haines ([robert.haines@manchester.ac.uk](mailto:robert.haines@manchester.ac.uk))
 
-You may contact members individually or collectively. 
+You may contact members individually or collectively.
+Note that if you contact members individually, other members may still be involved in resolving the issue.
+If members are subject of a report themselves, they will not be involved in the resolution of the issue as members of the Code of Conduct Committee, but may be addressed by other members as reported subjects to resolve the issue.
 
 ## Attribution
 


### PR DESCRIPTION
**Related issues**

Refs: https://github.com/citation-file-format/governance/issues/2

**Describe the changes made in this pull request**

- Change code of conduct document to make the CoC Committee the new point-of-contact
- Add section listing the committee members with email addresses (as `mailto:` links).

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Review the changes in `CODE_OF_CONDUCT.md`.
