### PR TITLE
Fix #477: Add regex101 link for strictish-string

### DIFF
--- a/schema-guide.md
+++ b/schema-guide.md
@@ -4044,7 +4044,7 @@ When there are multiple licenses, it is assumed their relationship is OR, not AN
 
 ### `definitions.strictish-string`
 
-- **type**: `string` with pattern `"^(\\S+)( \\S+)*$"`
+- **type**: `string` with pattern [`"^(\\S+)( \\S+)*$"`](https://regex101.com/r/SyW84W/1)
 - **required**: N/A
 - **description**: Nonempty string without any leading spaces, trailing spaces or double spaces.
 - **usage**:<br><br>


### PR DESCRIPTION
**Related issues**

Fixes #477

(For autoclosure of issues when PR is merged use `Fixes #<issue-number>` syntax)

**Describe the changes made in this pull request**

- Adds a regex101 link to definition of strictish string

**Review checklist**

- [ ] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout <branch>
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
<do other things>
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [ ] `<do other things>`
