### PR TITLE
Adapt documentation for `reference.number` to include article numbers/identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Narrowed definition of URL strings to raise error when trailing characters, notably whitespace, are used. PR [#468](https://github.com/citation-file-format/citation-file-format/pull/468).
 - Narrowed definition of ORCID strings to raise error when trailing characters, notably whitespace, are used. Issue [#392](https://github.com/citation-file-format/citation-file-format/issues/392); PR [#467](https://github.com/citation-file-format/citation-file-format/pull/467).
 - Added regex to the schema to help avoid leading spaces, trailing spaces, and double spaces in many string fields. Issue [#380](https://github.com/citation-file-format/citation-file-format/issues/380); PR [#466](https://github.com/citation-file-format/citation-file-format/pull/466).
+- CLarified documentation for `reference.number` to include article numbers. Issue [#347](https://github.com/citation-file-format/citation-file-format/issues/347); PR [#519](https://github.com/citation-file-format/citation-file-format/pull/519).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Narrowed definition of URL strings to raise error when trailing characters, notably whitespace, are used. PR [#468](https://github.com/citation-file-format/citation-file-format/pull/468).
 - Narrowed definition of ORCID strings to raise error when trailing characters, notably whitespace, are used. Issue [#392](https://github.com/citation-file-format/citation-file-format/issues/392); PR [#467](https://github.com/citation-file-format/citation-file-format/pull/467).
 - Added regex to the schema to help avoid leading spaces, trailing spaces, and double spaces in many string fields. Issue [#380](https://github.com/citation-file-format/citation-file-format/issues/380); PR [#466](https://github.com/citation-file-format/citation-file-format/pull/466).
-- CLarified documentation for `reference.number` to include article numbers. Issue [#347](https://github.com/citation-file-format/citation-file-format/issues/347); PR [#519](https://github.com/citation-file-format/citation-file-format/pull/519).
+- Clarified documentation for `reference.number` to include article numbers. Issue [#347](https://github.com/citation-file-format/citation-file-format/issues/347); PR [#519](https://github.com/citation-file-format/citation-file-format/pull/519).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Narrowed definition of URL strings to raise error when trailing characters, notably whitespace, are used. PR [#468](https://github.com/citation-file-format/citation-file-format/pull/468).
 - Narrowed definition of ORCID strings to raise error when trailing characters, notably whitespace, are used. Issue [#392](https://github.com/citation-file-format/citation-file-format/issues/392); PR [#467](https://github.com/citation-file-format/citation-file-format/pull/467).
 - Added regex to the schema to help avoid leading spaces, trailing spaces, and double spaces in many string fields. Issue [#380](https://github.com/citation-file-format/citation-file-format/issues/380); PR [#466](https://github.com/citation-file-format/citation-file-format/pull/466).
-- Clarified documentation for `reference.number` to include article numbers. Issue [#347](https://github.com/citation-file-format/citation-file-format/issues/347); PR [#519](https://github.com/citation-file-format/citation-file-format/pull/519).
+- Clarified documentation for `reference.number` to include article identifiers (which aren't necessarily numbers). Issue [#347](https://github.com/citation-file-format/citation-file-format/issues/347); PR [#519](https://github.com/citation-file-format/citation-file-format/pull/519).
 
 ### Fixed
 

--- a/schema-guide.md
+++ b/schema-guide.md
@@ -3405,7 +3405,7 @@ When there are multiple licenses, it is assumed their relationship is OR, not AN
 
 - **type**: `string` or `number`
 - **required**: `false`
-- **description**: The (library) [accession number](https://en.wikipedia.org/wiki/Accession_number) for a work.
+- **description**: The number of a work, e.g., an article identifier (such as *86* or *e86* for [this paper](https://doi.org/10.7717/peerj-cs.86)) or a (library) [accession number](https://en.wikipedia.org/wiki/Accession_number).
 - **usage**:<br><br>
     ```yaml
     preferred-citation:

--- a/schema.json
+++ b/schema.json
@@ -1582,6 +1582,10 @@
                 },
                 "number": {
                     "description": "The number of a work, e.g., an article identifier or an accession number.",
+                    "examples": [
+                        "123",
+                        "123ABC-4"
+                    ],
                     "oneOf": [
                         {
                             "$ref": "#/$defs/strictish-string"

--- a/schema.json
+++ b/schema.json
@@ -1581,7 +1581,7 @@
                     "description": "Notes pertaining to the work."
                 },
                 "number": {
-                    "description": "The accession number for a work.",
+                    "description": "The number of a work, e.g., an article identifier or an accession number.",
                     "oneOf": [
                         {
                             "$ref": "#/$defs/strictish-string"


### PR DESCRIPTION
**Related issues**

Refs: #347

**Describe the changes made in this pull request**

- Implements the decision to let `reference.number` to be the suitable field for providing article numbers/IDs by adapting documentation.

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [ ] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [ ] Please run tests locally.
<!-- 
CONTRIBUTORS: Please replace <do other things> in the snippet below 
with something that reviewers should do to test and review your contribution!
-->
```bash
cd $(mktemp -d --tmpdir cff.XXXXXX)
git clone https://github.com/citation-file-format/citation-file-format .
git checkout 347-article-number
python3 -m venv env
source env/bin/activate
pip install --upgrade pip wheel setuptools
pip install -r requirements.txt
pytest
```
<!-- 
CONTRIBUTORS: Please replace `<do other things>` in the checklist item below 
with something that reviewers should do additionally
to test and review your contribution!
-->
- [x] Make sure that schema and documentation and other relevant places reflect the intent of #347.
