### PR TITLE
Instantiate the JSON schema validator once instead of 308 times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Python versions run in CI to remove end-of-life versions and add newer releases
 - Replace real ORCID with example ORCID from https://orcid.org/1234-5678-9101-1121
 - Provide contact details for the Code of Conduct Committee in the CoC document
+- Speed up the test suite
 
 ## [1.2.0] - 2021-05-31
 

--- a/tests/validate_schema_guide.py
+++ b/tests/validate_schema_guide.py
@@ -37,6 +37,7 @@ def test():
         schema_path = os.path.join(os.path.dirname(__file__), "..", "schema.json")
         with open(schema_path, "r") as sf:
             schema_data = json.loads(sf.read())
+            validator = jsonschema.Draft7Validator(schema=schema_data, format_checker=jsonschema.FormatChecker())
             for i_snippet, snippet in enumerate(snippets):
                 if "# incorrect" in snippet["text"]:
                     continue
@@ -44,7 +45,7 @@ def test():
                 passes = False
                 while not passes:
                     try:
-                        jsonschema.validate(instance=instance, schema=schema_data, format_checker=jsonschema.FormatChecker())
+                        validator.validate(instance=instance)
                         passes = True
                         print("snippet {0}/{1} (chars {2}-{3}): OK".format(i_snippet + 1, len(snippets), snippet["start"], snippet["end"]))
                     except jsonschema.ValidationError as e:


### PR DESCRIPTION
**Describe the changes made in this pull request**

With this change, the `validate_schema_guide.py` testing runtime drops from ~9 seconds to under half a second.

I'm interested in improving the design of the `validate_schema_guide.py` tests, but this is a critical performance improvement that is very easy to review on its own.

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.

