### PR TITLE
Drop Python 3.8 and 3.9 testing

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ rejected as expected.
 
 ## Dependencies
 
-- Python 3.6 or higher
+- Python 3.10 or higher
 - [cffconvert](https://pypi.org/project/cffconvert/) version 1.0.0 or higher
 - [pytest](https://pypi.org/project/pytest/)
 


### PR DESCRIPTION
**Describe the changes made in this pull request**

The CHANGELOG already notes that EOL Python releases have been dropped from the test suite, but those changes haven't been released yet so this change falls under that existing CHANGELOG entry.

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.
