### PR TITLE
Fix the "Build Status" badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Citation File Format
 
-[![Build Status](https://github.com/citation-file-format/citation-file-format/workflows/testing/badge.svg?branch=main)](https://github.com/citation-file-format/citation-file-format/actions/workflows/testing.yml?query=branch%3Amain)
+[![Build Status](https://github.com/citation-file-format/citation-file-format/actions/workflows/testing.yml/badge.svg?branch=main)](https://github.com/citation-file-format/citation-file-format/actions/workflows/testing.yml?query=branch%3Amain)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1003149.svg)](https://doi.org/10.5281/zenodo.1003149)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Project homepage](https://img.shields.io/badge/Project%20homepage-citation--file--format.github.io-ff0080)](https://citation-file-format.github.io)


### PR DESCRIPTION
**Describe the changes made in this pull request**

Previously, the badge showed "no status" due to an incorrect URL. Now, with the URL fixed, the badge shows "passing".

**Review checklist**

- [x] Please check if the pull request is against the correct branch  
(format/schema/semantic documentation changes: `develop`; typos, meta files, etc.: `main`)
- [x] Please check if all changes are recorded in `CHANGELOG.md` and adapt if necessary.
- [x] Please run tests locally.

Review the rendered badge in the README in my branch:

https://github.com/kurtmckee/pr-citation-file-format/blob/fix-readme-badge/README.md